### PR TITLE
Include security tab in tile installation instructions

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -62,9 +62,6 @@ To configure PCF Healthwatch:
 		1. Navigate to the Elastic Runtime Tile
 		1. Navigate to `Credentials`
 		1. Note the password for the `healthwatch_ui` user. Input in the Healthwatch tile
-	<p class="note"><strong>Note</strong>: If you are not on PCF 1.11.10 or later, you will need to configure this user manually
-	For instructions on how to do this, reference the <a href="#uaa-authorities>Configure UAA Authorities</a> section
-	</p>
 
 1. Return to the Ops Manager Installation Dashboard and click **Apply Changes**.
 

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -7,11 +7,12 @@ This topic describes how to install and configure Pivotal Cloud Foundry (PCF) He
 
 ##<a id='prereqs'></a> Prerequisites
 
-Before deploying PCF Healthwatch, ensure that you have installed:
+Before deploying PCF Healthwatch, ensure that you have:
 
 * PCF Ops Manager v1.11.0 or later
 * PCF Elastic Runtime v1.11.0 or later
 * the [UAA Command Line Interface (UAAC)](https://github.com/cloudfoundry/cf-uaac)
+* 3 Reserved IPs in a Service Network for the Ops Manager tile
 
 ##<a id='install'></a> Install PCF Healthwatch
 
@@ -55,6 +56,15 @@ To configure PCF Healthwatch:
 	1. Enter a VM type in **BOSH Healthcheck VM Type**.
 		<p class="note"><strong>Note</strong>: You can find the availability zone and VM type values by submitting the <code>YOUR-OPSMAN-URL/api/v0/deployed/cloud_config</code> Ops Manager API request.</p>
 	1. Click **Save**.
+1. Navigate to **Security** and do the following: 
+
+	1. Enter the credentials for the `healthwatch_ui` user from Elastic Runtime
+		1. Navigate to the Elastic Runtime Tile
+		1. Navigate to `Credentials`
+		1. Note the password for the `healthwatch_ui` user. Input in the Healthwatch tile
+	<p class="note"><strong>Note</strong>: If you are not on PCF 1.11.10 or later, you will need to configure this user manually
+	For instructions on how to do this, reference the <a href="#uaa-authorities>Configure UAA Authorities</a> section
+	</p>
 
 1. Return to the Ops Manager Installation Dashboard and click **Apply Changes**.
 


### PR DESCRIPTION
noticed that this was missing from our docs. 
Also added some additional info requiring the user to create a service network prior to installing the tile