### PR TITLE
Document requirement to reinstall healthwatch bosh plugin after BOSH Director recreated

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -3,6 +3,16 @@ title: Installing and Configuring PCF Healthwatch
 owner: PCF Healthwatch
 ---
 
+<style>
+    .note.warning {
+        background-color: #fdd;
+        border-color: #fbb
+    }
+    .note.warning:before {
+        color: #f99;
+     }
+</style>
+
 This topic describes how to install and configure Pivotal Cloud Foundry (PCF) Healthwatch. For a list of compatible Ops Manager and Elastic Runtime versions, see [Product Snapshot](index.html#snapshot).
 
 ##<a id='install'></a> Install PCF Healthwatch
@@ -55,6 +65,13 @@ To configure PCF Healthwatch, perform the following steps:
 1. Return to the Ops Manager Installation Dashboard and click **Apply Changes**.
 
 ##<a id='bosh-metrics'></a> Getting BOSH Health Metrics into PCF Healthwatch
+
+<p class="note warning">
+<strong>KNOWN ISSUE: </strong>
+The BOSH Director Healthwatch plugin must be reinstalled every time that the BOSH Director is recreated.  
+The BOSH Director is recreated when upgrading Ops Manager; as well as installing, upgrading and deleting data service tiles 
+like MySQL, RabbitMQ or Redis
+</p>
 
 Forwarding BOSH health metrics to PCF Healthwatch currently requires manual configuration. You must have PCF Admin permissions to configure the BOSH Director.
 

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -3,16 +3,6 @@ title: Installing and Configuring PCF Healthwatch
 owner: PCF Healthwatch
 ---
 
-<style>
-    .note.warning {
-        background-color: #fdd;
-        border-color: #fbb
-    }
-    .note.warning:before {
-        color: #f99;
-     }
-</style>
-
 This topic describes how to install and configure Pivotal Cloud Foundry (PCF) Healthwatch. For a list of compatible Ops Manager and Elastic Runtime versions, see [Product Snapshot](index.html#snapshot).
 
 ##<a id='install'></a> Install PCF Healthwatch
@@ -66,20 +56,17 @@ To configure PCF Healthwatch, perform the following steps:
 
 ##<a id='bosh-metrics'></a> Getting BOSH Health Metrics into PCF Healthwatch
 
-<p class="note warning">
-<strong>KNOWN ISSUE: </strong>
-The BOSH Director Healthwatch plugin must be reinstalled every time that the BOSH Director is recreated.  
-The BOSH Director is recreated when upgrading Ops Manager; as well as installing, upgrading and deleting data service tiles 
-like MySQL, RabbitMQ or Redis
-</p>
-
 Forwarding BOSH health metrics to PCF Healthwatch currently requires manual configuration. You must have PCF Admin permissions to configure the BOSH Director.
 
-<p class="note"><strong>Note</strong>: The manual configuration is required for the alpha and beta releases of PCF Healthwatch.</p>
+To configure the BOSH Director, follow the instructions below.
 
-To configure the BOSH Director, follow the instructions below. The referenced plugins are available on [Pivotal Network](https://network.pivotal.io/products/p-healthwatch).
+<p class="note">
+<strong>Note</strong>:
+You must reinstall the BOSH Director Healthwatch plugin every time the BOSH Director is recreated.  
+The BOSH Director is recreated when you upgrade Ops Manager and install, upgrade, and delete data service tiles (for example, MySQL, RabbitMQ, or Redis).
+</p>
 
-1. Copy `healthwatch-bosh-plugin`, `run.sh`, and `healthwatch-bosh-plugin.json` to the BOSH Director.
+1. Copy `healthwatch-bosh-plugin`, `run.sh`, and `healthwatch-bosh-plugin.json` to the BOSH Director. The referenced plugins are available on [Pivotal Network](https://network.pivotal.io/products/p-healthwatch).
 1. Run `sudo` in the BOSH Director.
 1. Create the following directories:
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -20,6 +20,13 @@ The Pivotal Cloud Foundry (PCF) Healthwatch tile is currently in beta and is int
 Do not use this product in a PCF production environment.
 </p>
 
+<p class="note warning">
+<strong>KNOWN ISSUE: </strong>
+The BOSH Director Healthwatch plugin must be [reinstalled](installing.html#bosh-metrics) every time that the BOSH Director is recreated.  
+The BOSH Director is recreated when upgrading Ops Manager; as well as installing, upgrading and deleting data service tiles 
+like MySQL, RabbitMQ or Redis
+</p>
+
 ##<a id='v1.0.6'></a>v1.0.6
 **Release Date: September 26, 2017**
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -20,13 +20,6 @@ The Pivotal Cloud Foundry (PCF) Healthwatch tile is currently in beta and is int
 Do not use this product in a PCF production environment.
 </p>
 
-<p class="note warning">
-<strong>KNOWN ISSUE: </strong>
-The BOSH Director Healthwatch plugin must be [reinstalled](installing.html#bosh-metrics) every time that the BOSH Director is recreated.  
-The BOSH Director is recreated when upgrading Ops Manager; as well as installing, upgrading and deleting data service tiles 
-like MySQL, RabbitMQ or Redis
-</p>
-
 ##<a id='v1.0.6'></a>v1.0.6
 **Release Date: September 26, 2017**
 


### PR DESCRIPTION
This is a known issue that occurs every time the BOSH Director is recreated; which turns out to be a  fairly common event in a production foundation

For example, the BOSH Director is recreated:

* when upgrading Ops Manager
* installing, upgrading or deleting a data service tiles

It [caught the CloudOps EU team by surprise in Tracker's PCF environment](https://docs.google.com/a/pivotal.io/document/d/145Sa8Pmi6LTtolkfTePu2IvnG6dqr2ugibOR9uKLOnQ/edit?disco=AAAABTF-TvM) - we think it should be called out explicitly as a a Known Issue in the docs.

