### PR TITLE
Update docs to reflect Canary App rename [#152200817]

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -30,7 +30,7 @@ PCF Healthwatch creates the following functional apps:
 * BOSH Director Health Check: the `bosh-health-check` app 
 * BOSH Deployment Task Check: the `bosh-task-check` app 
 * CLI Command Health Check: the `cf-health-check` app 
-* Apps Manager Uptime and Response Check: the `appsmanager-health-check` app 
+* Canary App Uptime and Response Check: the `canaryapp-health-check` app
 * Ops Manager Uptime Check: the `opsmanager-health-check` app
 
 For information on how to scale these PCF Healthwatch resources, see [PCF Healthwatch Resources](resources.html#healthwatch-apps).

--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -101,7 +101,7 @@ Issues with Ops Manager health can impact an operator's ability to perform an up
 </tr>
 </table>
 
-##<a id='appsman'></a>Healthwatch: Apps Manager Health
+##<a id='canaryapp'></a>Healthwatch: Canary App Health
 
 App availability and responsiveness issues can result in significant end user impacts. PCF Healthwatch uses Apps Manager as a canary app and continuously checks its health. Because of the functions Apps Manager provides, Pivotal recommends it as a canary for insight into the performance of other apps on the foundation.
 
@@ -114,13 +114,13 @@ App availability and responsiveness issues can result in significant end user im
 </tr>
 <tr>
   <td>Apps Manager availability</td>
-  <td><code>healthwatch.health.check.AppsMan.available</code></td>
+  <td><code>healthwatch.health.check.CanaryApp.available</code></td>
   <td>1 min</td>
   <td><code>1</code> = pass or <code>0</code> = fail</td>
 </tr>
 <tr>
   <td>Aps Manager response time</td>
-  <td><code>healthwatch.health.check.AppsMan.responseTime</code></td>
+  <td><code>healthwatch.health.check.CanaryApp.responseTime</code></td>
   <td>1 min</td>
   <td>Time in ms</td>
 </tr>

--- a/resources.html.md.erb
+++ b/resources.html.md.erb
@@ -70,7 +70,7 @@ If you want to scale the functional apps created by PCF Healthwatch, see the fol
   By default, this is scaled to 2. It is recommended not to exceed 3 runners at once.
 * **CLI Command Health Check** (the `cf-health-check` app).
   By default, this is scaled to 2. It is recommended not to exceed 3 runners at once.
-* **Apps Manager Uptime and Response Check** (the `appsmanager-health-check` app).
+* **Canary App Uptime and Response Check** (the `canaryapp-health-check` app).
   By default, this is scaled to 2. It is recommended not to exceed 3 runners at once.
 * **Ops Manager Uptime Check** (the `opsmanager-health-check` app).
   By default, this is scaled to 2. It is recommended not to exceed 3 runners at once.


### PR DESCRIPTION
**NOTE**
This change only applies to docs for 1.1 GA

Signed-off-by: Dennis Collinson <dcollinson@pivotal.io>