### PR TITLE
curl /info now shows "PCF Healthwatch available"

### DIFF
--- a/api/alerts.html.md.erb
+++ b/api/alerts.html.md.erb
@@ -23,7 +23,7 @@ Test the availability of the Healthwatch API by hitting the `/info` endpoint wit
 curl -G healthwatch-api.SYSTEM-DOMAIN/info
 ```
 
-The expected response is a `200`/`OK` with the message `"HAPI is happy"`.
+The expected response is a `200`/`OK` with the message `"PCF Healthwatch available"`.
 
 ##<a id='get'></a>View all alert configurations
 ### `GET /alert-configurations`

--- a/api/canary-configuration.html.md.erb
+++ b/api/canary-configuration.html.md.erb
@@ -22,7 +22,7 @@ To check the availability of the Healthwatch API, run the following command:
 $ curl -G healthwatch-api.SYSTEM-DOMAIN/info
 ```
 
-A successful response is a `200`/`OK` with the message `"HAPI is happy"`.
+A successful response is a `200`/`OK` with the message `"PCF Healthwatch available"`.
 
 ## <a id='get'></a>View Canary URL
 

--- a/api/free-chunks.html.md.erb
+++ b/api/free-chunks.html.md.erb
@@ -24,7 +24,7 @@ Test the availability of the Healthwatch API by hitting the `/info` endpoint wit
 curl -G healthwatch-api.SYSTEM-DOMAIN/info
 ```
 
-The expected response is a `200`/`OK` with the message `"HAPI is happy"`.
+The expected response is a `200`/`OK` with the message `"PCF Healthwatch available"`.
 
 ## <a id='get'></a>View all free chunk configurations
 ### `GET /v1/free-chunks`


### PR DESCRIPTION
curl -G healthwatch-api.SYSTEM-DOMAIN/info now returns 200 OK
with a message of "PCF Healthwatch available". Correct docs to reflect
this.