### PR TITLE
Adds an example SLI query for canary app availability [#158378094]

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -126,7 +126,7 @@ The returned values of `[ 1536166538, "10" ]` and `[ 1536166598, "8" ]` mean the
 
 #### Example: Query the latest value for the CF Push Health Check
 
-This queries the latest value stored in Log Cache for the CF Push Health Check:
+This queries the latest value stored in Log Cache for the `cf push` Health Check:
 
 ```
 curl -G "https://log-cache.SYSTEM_HOST/api/v1/query" --data-urlencode 'query=health_check_cliCommand_push{source_id="healthwatch-forwarder"}' -H "Authorization: $(cf oauth-token)"
@@ -153,8 +153,8 @@ curl -G "https://log-cache.SYSTEM_HOST/api/v1/query" --data-urlencode 'query=hea
 }
 ```
 
-The result value of "1" means that CF Push is currently working. Any other value means that CF Push has timed out or failed.
-This result could be used by automation tools waiting for CF Push to become available.
+The result value of "1" means that `cf push` is currently working. Any other value means that `cf push` has timed out or failed.
+This result could be used by automation tools waiting for `cf push` to become available.
 
 #### Example: Canary App Availability SLI
 
@@ -192,7 +192,7 @@ curl -G "https://log-cache.SYSTEM_HOST/api/v1/query_range?start=1537782809&end=1
 ```
 
 The `query_range` endpoint is useful for seeing values over time with a fixed interval (step). This is useful
-for charting, but let's use the results to calculate up-time using a critical threshold of `v < 1`:
+for charting, but you can also use it to calculate uptime, based on a critical threshold of `v < 1`:
 
 ```
 results [1 1 1 1 1 0 1 1]

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -76,7 +76,7 @@ You can access Healthwatch data directly with PromQL queries to the Log Cache AP
 - `/api/v1/query`
 - `/api/v1/query_range` 
 
-#### Format a Query
+#### Query Format
 
 To form the promQL query for a metric, do the following:
 
@@ -86,9 +86,9 @@ To form the promQL query for a metric, do the following:
 
 See the [Querying Prometheus](https://prometheus.io/docs/prometheus/latest/querying/basics/) for for more information about query syntax.
 
-#### Example: Diego Available Free Chunks
+#### Example: Query recent values of Diego Available Free Chunks
 
-The following example shows a query for the number of free chunks over the past two minutes:
+This queries all values of `Diego_AvailableFreeChunks` over the past two minutes:
 
 ```
 curl -G "https://log-cache.SYSTEM_HOST/api/v1/query" --data-urlencode 'query=Diego_AvailableFreeChunks{source_id="healthwatch-forwarder"}[2m]' -H "Authorization: $(cf oauth-token)"
@@ -122,14 +122,46 @@ curl -G "https://log-cache.SYSTEM_HOST/api/v1/query" --data-urlencode 'query=Die
 
 ```
 
-The returned values of `[ 1536166538000000000, "10" ]` and `[ 1536166598000000000, "8" ]` mean there were 10 free chunks two minutes ago and eight free chunks one minute ago.
+The returned values of `[ 1536166538, "10" ]` and `[ 1536166598, "8" ]` mean there were 10 free chunks two minutes ago and eight free chunks one minute ago.
+
+#### Example: Query the latest value for the CF Push Health Check
+
+This queries the latest value stored in Log Cache for the CF Push Health Check:
+
+```
+curl -G "https://log-cache.SYSTEM_HOST/api/v1/query" --data-urlencode 'query=health_check_cliCommand_push{source_id="healthwatch-forwarder"}' -H "Authorization: $(cf oauth-token)"
+
+{
+  "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {
+          "deployment": "p-healthwatch-b8f99d6a724dbee699cc",
+          "index": "2336cbbe-e526-45d4-816e-dd2352d4fa0c",
+          "job": "healthwatch-forwarder",
+          "origin": "healthwatch"
+        },
+        "value": [
+          1537826971,
+          "1"
+        ]
+      }
+    ]
+  }
+}
+```
+
+The result value of "1" means that CF Push is currently working. Any other value means that CF Push has timed out or failed.
+This result could be used by automation tools waiting for CF Push to become available.
 
 #### Example: Canary App Availability SLI
 
-The Log Cache API can also query over a range to measure SLI adherence:
+The Log Cache API can also execute the same query multiple times over a range:
 
 ```
-curl -G "https://log-cache.SYSTEM_HOST/api/v1/query_range?start=1537782809&end=1537804131&step=60s" --data-urlencode 'query=health_check_CanaryApp_available{source_id="healthwatch-forwarder"}' -H "Authorization: $(cf oauth-token)" -k | jq .
+curl -G "https://log-cache.SYSTEM_HOST/api/v1/query_range?start=1537782809&end=1537804131&step=60s" --data-urlencode 'query=health_check_CanaryApp_available{source_id="healthwatch-forwarder"}' -H "Authorization: $(cf oauth-token)"
 
 {
   "status": "success",
@@ -159,8 +191,8 @@ curl -G "https://log-cache.SYSTEM_HOST/api/v1/query_range?start=1537782809&end=1
 }
 ```
 
-The `query_range` endpoint is useful for seeing values over time for a given query. This is very useful for charting,
-but let's use the results to calculate up time using a critical threshold of `v < 1`:
+The `query_range` endpoint is useful for seeing values over time with a fixed interval (step). This is useful
+for charting, but let's use the results to calculate up-time using a critical threshold of `v < 1`:
 
 ```
 results [1 1 1 1 1 0 1 1]
@@ -172,12 +204,14 @@ uptime = 7 / 8
 uptime = 87.5%
 ```
 
-This is subject to the retention time of the Log Cache service. You can discover the oldest metric stored with
+#### Log Cache Data Retention
+
+These queries are subject to the retention time of the Log Cache service. You can discover the oldest metric stored with
 the `/v1/meta` Log Cache API endpoint.
 
 ```
 curl -G "https://log-cache.SYSTEM_HOST/v1/meta" -H "Authorization: $(cf oauth-token)" -k | jq .meta | grep -A 4 healthwatch-forwarder
 ```
 
-If you would like to calculate uptime over a longer period of time, the instance count and/or RAM of the Doppler VM
+If you would like to query data over a longer period of time, the instance count and/or RAM of the Doppler VM
 must be scaled up.

--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -86,12 +86,12 @@ To form the promQL query for a metric, do the following:
 
 See the [Querying Prometheus](https://prometheus.io/docs/prometheus/latest/querying/basics/) for for more information about query syntax.
 
-#### Example 
+#### Example: Diego Available Free Chunks
 
 The following example shows a query for the number of free chunks over the past two minutes:
 
 ```
-curl -G "https://log-cache.SYSTEM_URL/api/v1/query" --data-urlencode 'query=Diego_AvailableFreeChunks{source_id="healthwatch-forwarder"}[2m]' -H "Authorization: $(cf oauth-token)"
+curl -G "https://log-cache.SYSTEM_HOST/api/v1/query" --data-urlencode 'query=Diego_AvailableFreeChunks{source_id="healthwatch-forwarder"}[2m]' -H "Authorization: $(cf oauth-token)"
 
 {
   "status": "success",
@@ -123,3 +123,61 @@ curl -G "https://log-cache.SYSTEM_URL/api/v1/query" --data-urlencode 'query=Dieg
 ```
 
 The returned values of `[ 1536166538000000000, "10" ]` and `[ 1536166598000000000, "8" ]` mean there were 10 free chunks two minutes ago and eight free chunks one minute ago.
+
+#### Example: Canary App Availability SLI
+
+The Log Cache API can also query over a range to measure SLI adherence:
+
+```
+curl -G "https://log-cache.SYSTEM_HOST/api/v1/query_range?start=1537782809&end=1537804131&step=60s" --data-urlencode 'query=health_check_CanaryApp_available{source_id="healthwatch-forwarder"}' -H "Authorization: $(cf oauth-token)" -k | jq .
+
+{
+  "status": "success",
+  "data": {
+    "resultType": "matrix",
+    "result": [
+      {
+        "metric": {
+          "deployment": "cf-abc-123",
+          "index": "9496f02a-0a40-427a-b2e3-189e30064031",
+          "job": "healthwatch-forwarder",
+          "origin": "healthwatch"
+        },
+        "values": [
+          [ 1537790009, "1" ],
+          [ 1537790069, "1" ],
+          [ 1537790129, "1" ],
+          [ 1537790189, "1" ],
+          [ 1537790249, "1" ],
+          [ 1537790309, "0" ],
+          [ 1537790369, "1" ],
+          [ 1537790429, "1" ]
+        ],
+      }
+    ]
+  }
+}
+```
+
+The `query_range` endpoint is useful for seeing values over time for a given query. This is very useful for charting,
+but let's use the results to calculate up time using a critical threshold of `v < 1`:
+
+```
+results [1 1 1 1 1 0 1 1]
+number_of_failed_results (v < 1) = 1
+total_number_of_results = 8
+
+uptime = (total_number_of_results - number_of_failed_results) / total_number_of_results
+uptime = 7 / 8
+uptime = 87.5%
+```
+
+This is subject to the retention time of the Log Cache service. You can discover the oldest metric stored with
+the `/v1/meta` Log Cache API endpoint.
+
+```
+curl -G "https://log-cache.SYSTEM_HOST/v1/meta" -H "Authorization: $(cf oauth-token)" -k | jq .meta | grep -A 4 healthwatch-forwarder
+```
+
+If you would like to calculate uptime over a longer period of time, the instance count and/or RAM of the Doppler VM
+must be scaled up.


### PR DESCRIPTION
This includes an example query for the canary app availability sli. This example is in line with how we plan to do uptime/error budget in healthwatch. It is not a simple query that spits out 9s. We could (and have) written a simple query that does this, but only because the metric value of 1 = healthy and 0 = fail which does not apply to all cases, and may only apply to black box pass/fail cases.

Here's how we plan to do sli calculation in healthwatch:
```
indicators:
- name: canary_app_availability
  service_level: {}
  promql: health_check_CanaryApp_available{source_id="healthwatch-forwarder"}
  thresholds:
  - level: critical
    lt: 1
```
So here we are saying that the canary app indicator is in a critical state if the value is less than 1. Notice that the promql has no ranges/aggregates. We *could* do an average over 5 minutes and our threshold could be a fraction, but this may be perceived as "fudging the number" as they say. If we run this query 60 times over the last hour, and we are in a critical state once, the uptime is 59/60 or 98.3%.

Let's look at a more interesting example to see why this is necessary.
```
indicators:
- name: http_latency
  description: Service level is in adherence if 95% of requests complete within 1 second.
  service_level:
    objective: 0.9999 # defined by operators, 259 seconds of error budget allowed over the last 30 days
    
  # taking all endpoints into account, what percentage of requests complete within a second
  promql: sum(rate(http_request_duration_seconds_bucket{le="1"}[1m])) / sum(rate(http_request_duration_seconds_count[1m]))
  thresholds:
  - level: critical
    lt: 0.95 # defined by component developer, can be overridden by operator
```
This is a latency SLI. We can get all values over the past 30 days by running a query_range against log-cache. We should evaluate this with a step of 15s for granularity. For each result that is less than 0.95, we subtract 15 seconds from the error budget. So if it is in a critical state 10 times in the last 30 days, we have 259 - (10 * 15) = 159 seconds of error budget remaining. Stephen Thorne's [post](https://medium.com/@jerub/service-level-objectives-in-practice-ed1200502d5) has some good information on this!