### PR TITLE
add a section for 1.6.2 release note [#168768302]

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -50,7 +50,9 @@ The Indicator Protocol Beta Dashboard charts are populated using data from Log C
 No corrective action is required. The issue will self-resolve if possible.
 
 
-## <a id='v1.6.2'></a>v1.6.2
+## <a id='v1.6.2'></a>v1.6.2 -- Withdrawn
+
+**This release has been removed from Pivotal Network.**
 
 **Release Date: September 11, 2019**
 
@@ -60,9 +62,13 @@ See release note for [v1.6.3](#v1.6.3)
 
 ### Known Issues
 
-####<a id='migration-fail'></a> Flyway migration would fail when upgrading
-v1.6.2 contains a bad flyway migration. This causes issues
-in upgrades from Pivotal Healthwatch v1.5. v1.6.2 is no longer available.
+####<a id='migration-fail'></a> Flyway migration fails during upgrade
+
+PCF Healthwatch v1.6.2 contains a bad flyway migration. This causes issues
+during upgrades from PCF Healthwatch v1.5.
+Due to this issue, PCF Healthwatch v1.6.2 is no longer available on Pivotal Network.
+
+Install or upgrade to PCF Healthwatch v1.6.3 instead.
 
 ## <a id='v1.6.1'></a>v1.6.1
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -50,6 +50,20 @@ The Indicator Protocol Beta Dashboard charts are populated using data from Log C
 No corrective action is required. The issue will self-resolve if possible.
 
 
+## <a id='v1.6.2'></a>v1.6.2
+
+**Release Date: September 11, 2019**
+
+### Features
+
+See release note for [v1.6.3](#v1.6.3)
+
+### Known Issues
+
+####<a id='migration-fail'></a> Flyway migration would fail when upgrading
+v1.6.2 contains a bad flyway migration. This causes issues
+in upgrades from Pivotal Healthwatch v1.5. v1.6.2 is no longer available.
+
 ## <a id='v1.6.1'></a>v1.6.1
 
 **Release Date: July 8, 2019**


### PR DESCRIPTION
We pulled 1.6.2 from pivnet a while ago, but there are customers already have the tile download (most likely through CI). We have since published 1.6.3 to resolve the issue. This PR is to backfill the release notes identifying the issue in 1.6.2 in case customer wondering.

Docs team, please change the wording, style where you see fit, thanks!

