### PR TITLE
2.0 add any missing exporter metrics

### DIFF
--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -16,114 +16,46 @@ including Tanzu Application Service Exporter and Enterprise PKS Exporter.
 Healthwatch generates metrics that describe the health of several platform components.
 These metrics can be used to calculate percent availability and error budgets.
 
+### SLI Tests
+
+We have a generic underlying component in our code called the `SLITestRunner`
+which can be configured to run tasks that will provide Service Level Indicators
+for command line applications and processes. Thus, you will see a pattern emerge
+between certain metrics (`bosh_sli_...`, `pas_sli_...`, `pks_sli_...`).
+
+| Metric                                                  | Description                                                                                                                      |
+|---------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `COMPONENT_deployments_status`                          | Bosh Deployments status, a 1 indicates a deployment is occurring on the director                                                 |
+| `COMPONENT_sli_duration_seconds_bucket`                 | Number of seconds it took for the SLI test suite to run, grouped by duration                                                     |
+| `COMPONENT_sli_duration_seconds_count`                  | Total number of metrics in all the buckets                                                                                       |
+| `COMPONENT_sli_duration_seconds_sum`                    | Total value of the metrics in all the buckets                                                                                    |
+| `COMPONENT_sli_exporter_status`                         | Exporter status, a 1 indicates the exporter is running and healthy                                                               |
+| `COMPONENT_sli_failures_total`                          | Total number of failures of the SLI test suite                                                                                   |
+| `COMPONENT_sli_run_duration_seconds`                    | Number of seconds it took for the SLI test suite to run                                                                          |
+| `COMPONENT_sli_runs_total`                              | Total number of runs of the SLI test suite. Use bosh_sli_failures_total / bosh_sli_runs_total to get failure rate.               |
+| `COMPONENT_sli_task_duration_seconds_bucket`            | Number of seconds it took for a particular task to run, grouped by duration                                                      |
+| `COMPONENT_sli_task_duration_seconds_count`             | Total number of metrics in all the buckets                                                                                       |
+| `COMPONENT_sli_task_duration_seconds_sum`               | Total value of the metrics in all the buckets                                                                                    |                                                                            |
+| `COMPONENT_sli_task_run_duration_seconds`               | Number of seconds it took for a particular task to run                                                                           |
+| `COMPONENT_sli_task_runs_total`                         | Total number of runs for a particular SLI task. Use bosh_sli_task_failures_total / bosh_sli_task_runs_total to get failure rate. |
+
+Where `COMPONENT` is the platform or CLI tested (e.g. `bosh`, `pas`, `pks`).
+
 ### <a id='cf-cli'></a>Cloud Foundry CLI Health
 
 The Cloud Foundry Command Line Interface (`cf` CLI) enables developers to create and manage apps on Tanzu Application Service. Healthwatch executes a continuous test suite to validate the core functions of the `cf` CLI.
 
 The table below provides information about the `cf` CLI health smoke tests and the metrics that are generated for these tests.
 
-<table class="nice">
-<tr>
-  <th>Test</th>
-  <th>Metric</th>
-  <th>Frequency</th>
-  <th>Description</th>
-</tr>
-<tr>
-  <td>Total test runs</td>
-  <td><code>pas_sli_runs_total</code></td>
-  <td>5 min</td>
-  <td>Number of times the test suite has run.</td>
-</tr>
-<tr>
-  <td>Total test fails</td>
-  <td><code>pas_sli_failures_total</code></td>
-  <td>5 min</td>
-  <td>Number of times the test suite has failed. The test suite fails if any of the tasks fail.</td>
-</tr>
-<tr>
-  <td>Total cf login fails</td>
-  <td><code>pas_sli_task_failures_total{task="login"}</code></td>
-  <td>5 min</td>
-  <td>Number of times login has failed.</td>
-</tr>
-<tr>
-  <td>Total cf push fails</td>
-  <td><code>pas_sli_task_failures_total{task="push"}</code></td>
-  <td>5 min</td>
-  <td>Number of times push has failed.</td>
-</tr>
-<tr>
-  <td>Total cf set-env fails</td>
-  <td><code>pas_sli_task_failures_total{task="setEnv"}</code></td>
-  <td>5 min</td>
-  <td>Number of times set-env has failed.</td>
-</tr>
-<tr>
-  <td>Total cf start fails</td>
-  <td><code>pas_sli_task_failures_total{task="start"}</code></td>
-  <td>5 min</td>
-  <td>Number of times start has failed.</td>
-</tr>
-<tr>
-  <td>Total cf logs fails</td>
-  <td><code>pas_sli_task_failures_total{task="logs"}</code></td>
-  <td>5 min</td>
-  <td>Number of times logs has failed.</td>
-</tr>
-<tr>
-  <td>Total cf stop fails</td>
-  <td><code>pas_sli_task_failures_total{task="stop"}</code></td>
-  <td>5 min</td>
-  <td>Number of times stop has failed.</td>
-</tr>
-<tr>
-  <td>Total cf delete fails</td>
-  <td><code>pas_sli_task_failures_total{task="delete"}</code></td>
-  <td>5 min</td>
-  <td>Number of times delete has failed.</td>
-</tr>
-<tr>
-  <td>Test app push time</td>
-  <td><code>pas_sli_task_run_duration_seconds{task="push"}</code></td>
-  <td>5 min</td>
-  <td>Time in seconds</td>
-</tr>
-<tr>
-  <td>Overall smoke test run time</td>
-  <td><code>pas_sli_run_duration_seconds</code></td>
-  <td>5 min</td>
-  <td>Time in seconds</td>
-</tr>
-</table>
-
-
-| Test            | Metric               | Frequency | Description                             |
-|-----------------|----------------------|-----------|-----------------------------------------|
-| Total test runs | `pas_sli_runs_total` | 5 min     | Number of times the test suite has run. |
-|                 |                      |           |                                         |
-|                 |                      |           |                                         |
-
-pas_sli_duration_seconds_bucket
-pas_sli_duration_seconds_count
-pas_sli_duration_seconds_sum
-pas_sli_exporter_status
-pas_sli_failures_total
-pas_sli_run_duration_seconds
-pas_sli_runs_total
-pas_sli_task_duration_seconds_bucket
-pas_sli_task_duration_seconds_count
-pas_sli_task_duration_seconds_sum
-pas_sli_task_failures_total{task="delete"}
-pas_sli_task_failures_total{task="login"}
-pas_sli_task_failures_total{task="logs"}
-pas_sli_task_failures_total{task="push"}
-pas_sli_task_failures_total{task="setEnv"}
-pas_sli_task_failures_total{task="start"}
-pas_sli_task_failures_total{task="stop"}
-pas_sli_task_run_duration_seconds{task="push"}
-pas_sli_task_runs_total
-
+| Metric                                       | Description                                                |
+|----------------------------------------------|------------------------------------------------------------|
+| `pas_sli_task_failures_total{task="delete"}` | Total number of failures for a `cf delete` command on PAS  |
+| `pas_sli_task_failures_total{task="login"}`  | Total number of failures for a `cf login` command on PAS   |
+| `pas_sli_task_failures_total{task="logs"}`   | Total number of failures for a `cf logs` command on PAS    |
+| `pas_sli_task_failures_total{task="push"}`   | Total number of failures for a `cf push` command on PAS    |
+| `pas_sli_task_failures_total{task="setEnv"}` | Total number of failures for a `cf set-env` command on PAS |
+| `pas_sli_task_failures_total{task="start"}`  | Total number of failures for a `cf start` command on PAS   |
+| `pas_sli_task_failures_total{task="stop"}`   | Total number of failures for a `cf stop` command on PAS    |
 
 ### PAS
 
@@ -146,89 +78,12 @@ to validate the core functions of the PKS CLI.
 The table below provides information about the
 PKS CLI Health smoke tests and the metrics that are generated for these tests.
 
-<table class="nice">
-<tr>
-  <th>Test</th>
-  <th>Metric</th>
-  <th>Frequency</th>
-  <th>Description</th>
-</tr>
-<tr>
-  <td>Total test runs</td>
-  <td><code>pks_sli_runs_total</code></td>
-  <td>1 min</td>
-  <td>Number of times the test suite runs.</td>
-</tr>
-<tr>
-  <td>Total test fails</td>
-  <td><code>pks_sli_failures_total</code></td>
-  <td>1 min</td>
-  <td>Number of times the test suite has failed. The test suite fails if any of the tasks fail.</td>
-</tr>
-<tr>
-  <td>Total pks login fails</td>
-  <td><code>pks_sli_task_failures_total{task="login"}</code></td>
-  <td>1 min</td>
-  <td>Number of times login has failed.</td>
-</tr>
-<tr>
-  <td>Total pks clusters fails</td>
-  <td><code>pks_sli_task_failures_total{task="clusters"}</code></td>
-  <td>1 min</td>
-  <td>Number of times list clusters has failed.</td>
-</tr>
-<tr>
-  <td>Total pks get-credentials fails</td>
-  <td><code>pks_sli_task_failures_total{task="get-credentials"}</code></td>
-  <td>1 min</td>
-  <td>Number of times get-credentials has failed. If there is no cluster created on the foundation,
-  this metric will report success without actually executing get-credentials command.</td>
-</tr>
-<tr>
-  <td>Total pks plans fails</td>
-  <td><code>pks_sli_task_failures_total{task="plans"}</code></td>
-  <td>1 min</td>
-  <td>Number of times list plans has failed.</td>
-</tr>
-<tr>
-  <td>Number of clusters</td>
-  <td><code>pks_sli_number_of_clusters</code></td>
-  <td>1 min</td>
-  <td>Number of Kubernetes clusters managed by PKS broker.</td>
-</tr>
-<tr>
-  <td>Get-credentials response time</td>
-  <td><code>pks_sli_task_run_duration_seconds{task="get-credentials"}</code></td>
-  <td>1 min</td>
-  <td>Time in seconds</td>
-</tr>
-<tr>
-  <td>Overall smoke test run time</td>
-  <td><code>pks_sli_run_duration_seconds</code></td>
-  <td>1 min</td>
-  <td>Time in seconds</td>
-</tr>
-</table>
-
-
-pks_sli_duration_seconds_bucket
-pks_sli_duration_seconds_count
-pks_sli_duration_seconds_sum
-pks_sli_exporter_status
-pks_sli_failures_total
-pks_sli_number_of_clusters
-pks_sli_run_duration_seconds
-pks_sli_runs_total
-pks_sli_task_duration_seconds_bucket
-pks_sli_task_duration_seconds_count
-pks_sli_task_duration_seconds_sum
-pks_sli_task_failures_total{task="clusters"}
-pks_sli_task_failures_total{task="get-credentials"}
-pks_sli_task_failures_total{task="login"}
-pks_sli_task_failures_total{task="plans"}
-pks_sli_task_run_duration_seconds{task="get-credentials"}
-pks_sli_task_runs_total
-
+| Metric                                                | Description                                                  |
+|-------------------------------------------------------|--------------------------------------------------------------|
+| `pks_sli_task_failures_total{task="clusters"}`        | Total number of failures for a `pks clusters` command        |
+| `pks_sli_task_failures_total{task="get-credentials"}` | Total number of failures for a `pks get-credentials` command |
+| `pks_sli_task_failures_total{task="login"}`           | Total number of failures for a `pks login` command           |
+| `pks_sli_task_failures_total{task="plans"}`           | Total number of failures for a `pks plans` command           |
 
 ### <a id='bosh-health'></a>BOSH Health
 
@@ -238,91 +93,23 @@ to validate the functionality of BOSH director.
 
 The table below provides information about the metrics that are generated.
 
-<table class="nice">
-<tr>
-  <th>Test</th>
-  <th>Metric</th>
-  <th>Frequency</th>
-  <th>Description</th>
-</tr>
-<tr>
-  <td>Total test runs</td>
-  <td><code>bosh_sli_runs_total</code></td>
-  <td>10 min</td>
-  <td>Number of times the test suite runs.</td>
-</tr>
-<tr>
-  <td>Total test fails</td>
-  <td><code>bosh_sli_failures_total</code></td>
-  <td>10 min</td>
-  <td>Number of times the test suite has failed. The test suite fails if any of the tasks has failed.</td>
-</tr>
-<tr>
-  <td>Total bosh deployments fails</td>
-  <td><code>bosh_sli_task_failures_total{task="deployments"}</code></td>
-  <td>10 min</td>
-  <td>Number of times list deployments has failed.</td>
-</tr>
-<tr>
-  <td>Total bosh deploy fails</td>
-  <td><code>bosh_sli_task_failures_total{task="deploy"}</code></td>
-  <td>10 min</td>
-  <td>Number of times deploy has failed.</td>
-</tr>
-<tr>
-  <td>Total bosh delete fails</td>
-  <td><code>bosh_sli_task_failures_total{task="delete"}</code></td>
-  <td>10 min</td>
-  <td>Number of times delete deployment has failed.</td>
-</tr>
-<tr>
-  <td>Total bosh tasks fails</td>
-  <td><code>bosh_sli_task_failures_total{task="tasks"}</code></td>
-  <td>10 min</td>
-  <td>Number of times list running tasks has failed.</td>
-</tr>
-<tr>
-  <td>BOSH task running</td>
-  <td><code>bosh_deployments_status</code></td>
-  <td>10 min</td>
-  <td><code>1</code> = running or <code>0</code> = idle. If bosh tasks fails, this metric will report <code>0</code>.</td>
-</tr>
-<tr>
-  <td>Overall smoke test run time</td>
-  <td><code>bosh_sli_run_duration_seconds</code></td>
-  <td>10 min</td>
-  <td>Time in seconds</td>
-</tr>
-</table>
-
 <p class="note"><strong>Note</strong>: Healthwatch deploys and deletes a VM named <code>bosh-health-exporter</code> as part of this test suite.</p>
 
-
-bosh_deployments_status                                  | Bosh Deployments status, a 1 indicates a deployment is occurring on the director
-bosh_sli_duration_seconds_bucket                         | Number of seconds it took for the SLI test suite to run, grouped by duration
-bosh_sli_duration_seconds_count                          | Total number of metrics in all the buckets
-bosh_sli_duration_seconds_sum                            | Total value of the metrics in all the buckets
-bosh_sli_exporter_status                                 | Exporter status, a 1 indicates the exporter is running and healthy
-bosh_sli_failures_total                                  | Total number of failures of the SLI test suite
-bosh_sli_run_duration_seconds                            | Number of seconds it took for the SLI test suite to run
-bosh_sli_runs_total                                      | Total number of runs of the SLI test suite. Use bosh_sli_failures_total / bosh_sli_runs_total to get failure rate.
-bosh_sli_task_duration_seconds_bucket                    | Number of seconds it took for a particular task to run, grouped by duration
-bosh_sli_task_duration_seconds_count                     | Total number of metrics in all the buckets
-bosh_sli_task_duration_seconds_sum                       | Total value of the metrics in all the buckets
-bosh_sli_task_failures_total{task="delete"}              | Total number of failures for an SLI "delete" task
-bosh_sli_task_failures_total{task="deploy"}              | Total number of failures for an SLI "deploy" task
-bosh_sli_task_failures_total{task="deployments"}         | Total number of failures for an SLI "deployments" task
-bosh_sli_task_failures_total{task="tasks"}               | Total number of failures for an SLI "tasks" task
-bosh_sli_task_run_duration_seconds                       | Number of seconds it took for a particular task to run
-bosh_sli_task_runs_total                                 | Total number of runs for a particular SLI task. Use bosh_sli_task_failures_total / bosh_sli_task_runs_total to get failure rate.
-healthwatch_boshExporter_ingressLatency_seconds_bucket   | Number of seconds it took to process a batch of Loggregator envelopes, grouped by latency
-healthwatch_boshExporter_ingressLatency_seconds_count    | Total number of metrics in all the buckets
-healthwatch_boshExporter_ingressLatency_seconds_sum      | Total value of the metrics in all the buckets
-healthwatch_boshExporter_ingress_envelopes               | Number of envelopes received by observability metrics agent
-healthwatch_boshExporter_metricConversion_seconds_bucket | Number of seconds it took to convert a bosh metric to a Prometheus gauge, grouped by duration
-healthwatch_boshExporter_metricConversion_seconds_count  | Total number of metrics in all the buckets
-healthwatch_boshExporter_metricConversion_seconds_sum    | Total value of the metrics in all the buckets
-healthwatch_boshExporter_status                          | Exporter status, a 1 indicates the exporter is running and healthy
+| Metric                                                     | Description                                                                                   |
+|------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `bosh_deployments_status`                                  | Bosh Deployments status, a 1 indicates a deployment is occurring on the director              |
+| `bosh_sli_task_failures_total{task="delete"}`              | Total number of failures for `bosh delete` command                                            |
+| `bosh_sli_task_failures_total{task="deploy"}`              | Total number of failures for `bosh deploy` command                                            |
+| `bosh_sli_task_failures_total{task="deployments"}`         | Total number of failures for `bosh deployments` command                                       |
+| `bosh_sli_task_failures_total{task="tasks"}`               | Total number of failures for `bosh tasks` command                                             |
+| `healthwatch_boshExporter_ingressLatency_seconds_bucket`   | Number of seconds it took to process a batch of Loggregator envelopes, grouped by latency     |
+| `healthwatch_boshExporter_ingressLatency_seconds_count`    | Total number of metrics in all the buckets                                                    |
+| `healthwatch_boshExporter_ingressLatency_seconds_sum`      | Total value of the metrics in all the buckets                                                 |
+| `healthwatch_boshExporter_ingress_envelopes`               | Number of envelopes received by observability metrics agent                                   |
+| `healthwatch_boshExporter_metricConversion_seconds_bucket` | Number of seconds it took to convert a bosh metric to a Prometheus gauge, grouped by duration |
+| `healthwatch_boshExporter_metricConversion_seconds_count`  | Total number of metrics in all the buckets                                                    |
+| `healthwatch_boshExporter_metricConversion_seconds_sum`    | Total value of the metrics in all the buckets                                                 |
+| `healthwatch_boshExporter_status`                          | Exporter status, a 1 indicates the exporter is running and healthy                            |
 
 
 ### <a id='cert-expiration'></a>Certificate Expiration Monitoring
@@ -359,63 +146,33 @@ App availability and responsiveness issues can significantly impact the experien
 Healthwatch allows operators to configure Canary URLs in the tile and expose whether the URL is running or not,
 along with the response time metrics.
 
-<table class="nice">
-<tr>
-  <th>Test</th>
-  <th>Metric</th>
-  <th>Frequency</th>
-  <th>Description</th>
-</tr>
-<tr>
-  <td>URL test success</td>
-  <td><code>probe_success{instance=~".*"}</code></td>
-  <td>15 s</td>
-  <td><code>1</code> = pass or <code>0</code> = fail</td>
-</tr>
-<tr>
-  <td>URL response time</td>
-  <td><code>probe_duration_seconds</code></td>
-  <td>15 s</td>
-  <td>Time in seconds</td>
-</tr>
-</table>
-
-
-
-
-
-
-`probe_dns_additional_rrs`                      | Returns number of entries in the additional resource record list
-`probe_dns_answer_rrs`                          | Returns number of entries in the answer resource record list
-`probe_dns_authority_rrs`                       | Returns number of entries in the authority resource record list
-`probe_dns_duration_seconds`                    | Duration of DNS request by phase
-`probe_dns_lookup_time_seconds`                 | Returns the time taken for probe dns lookup in seconds
-`probe_dns_serial`                              | Returns the serial number of the zone
-`probe_duration_seconds`                        | Returns how long the probe took to complete in seconds
-`probe_failed_due_to_regex`                     | Indicates if probe failed due to regex
-`probe_http_content_length`                     | Length of http content response
-`probe_http_duration_seconds`                   | Duration of http request by phase, summed over all redirects
-`probe_http_last_modified_timestamp_seconds`    | Returns the Last-Modified HTTP response header in unixtime
-`probe_http_redirects`                          | The number of redirects
-`probe_http_ssl`                                | Indicates if SSL was used for the final redirect
-`probe_http_status_code`                        | Response HTTP status code
-`probe_http_uncompressed_body_length`           | Length of uncompressed response body
-`probe_http_version`                            | Returns the version of HTTP of the probe response
-`probe_icmp_duration_seconds`                   | Duration of icmp request by phase
-`probe_icmp_reply_hop_limit`                    | Replied packet hop limit (TTL for ipv4)
-`probe_ip_addr_hash`                            | Specifies the hash of IP address. It's useful to detect if the IP address changes.
-`probe_ip_protocol`                             | Specifies whether probe ip protocol is IP4 or IP6
-`probe_ssl_earliest_cert_expiry`                | Returns earliest SSL cert expiry in unixtime
-`probe_ssl_last_chain_expiry_timestamp_seconds` | Returns last SSL chain expiry in unixtime
-`probe_ssl_last_chain_info`                     | Contains SSL leaf certificate information
-`probe_success`                                 | Displays whether or not the probe was a success
-`probe_tls_version_info`                        | Returns the TLS version used, or NaN when unknown
-
-
-
-
-\.new(Gauge|Counter|Const)
-
+| Metric                                          | Description                                                                        |
+|-------------------------------------------------|------------------------------------------------------------------------------------|
+| `probe_dns_additional_rrs`                      | Returns number of entries in the additional resource record list                   |
+| `probe_dns_answer_rrs`                          | Returns number of entries in the answer resource record list                       |
+| `probe_dns_authority_rrs`                       | Returns number of entries in the authority resource record list                    |
+| `probe_dns_duration_seconds`                    | Duration of DNS request by phase                                                   |
+| `probe_dns_lookup_time_seconds`                 | Returns the time taken for probe dns lookup in seconds                             |
+| `probe_dns_serial`                              | Returns the serial number of the zone                                              |
+| `probe_duration_seconds`                        | Returns how long the probe took to complete in seconds                             |
+| `probe_failed_due_to_regex`                     | Indicates if probe failed due to regex                                             |
+| `probe_http_content_length`                     | Length of http content response                                                    |
+| `probe_http_duration_seconds`                   | Duration of http request by phase, summed over all redirects                       |
+| `probe_http_last_modified_timestamp_seconds`    | Returns the Last-Modified HTTP response header in unixtime                         |
+| `probe_http_redirects`                          | The number of redirects                                                            |
+| `probe_http_ssl`                                | Indicates if SSL was used for the final redirect                                   |
+| `probe_http_status_code`                        | Response HTTP status code                                                          |
+| `probe_http_uncompressed_body_length`           | Length of uncompressed response body                                               |
+| `probe_http_version`                            | Returns the version of HTTP of the probe response                                  |
+| `probe_icmp_duration_seconds`                   | Duration of icmp request by phase                                                  |
+| `probe_icmp_reply_hop_limit`                    | Replied packet hop limit (TTL for ipv4)                                            |
+| `probe_ip_addr_hash`                            | Specifies the hash of IP address. It's useful to detect if the IP address changes. |
+| `probe_ip_protocol`                             | Specifies whether probe ip protocol is IP4 or IP6                                  |
+| `probe_ssl_earliest_cert_expiry`                | Returns earliest SSL cert expiry in unixtime                                       |
+| `probe_ssl_last_chain_expiry_timestamp_seconds` | Returns last SSL chain expiry in unixtime                                          |
+| `probe_ssl_last_chain_info`                     | Contains SSL leaf certificate information                                          |
+| `probe_success`                                 | Displays whether or not the probe was a success                                    |
+| `probe_tls_version_info`                        | Returns the TLS version used, or NaN when unknown                                  |
 
 ### Prometheus Exposition
 

--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -16,12 +16,13 @@ including Tanzu Application Service Exporter and Enterprise PKS Exporter.
 Healthwatch generates metrics that describe the health of several platform components.
 These metrics can be used to calculate percent availability and error budgets.
 
-### SLI Tests
+### <a id='sli-tests'></a>SLI Tests
 
-We have a generic underlying component in our code called the `SLITestRunner`
+We have a generic underlying component in our code called the SLI Test Runner
 which can be configured to run tasks that will provide Service Level Indicators
 for command line applications and processes. Thus, you will see a pattern emerge
 between certain metrics (`bosh_sli_...`, `pas_sli_...`, `pks_sli_...`).
+Here are the ones that `bosh`, `pas`, and `pks` should all have in common.
 
 | Metric                                                  | Description                                                                                                                      |
 |---------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
@@ -43,7 +44,9 @@ Where `COMPONENT` is the platform or CLI tested (e.g. `bosh`, `pas`, `pks`).
 
 ### <a id='cf-cli'></a>Cloud Foundry CLI Health
 
-The Cloud Foundry Command Line Interface (`cf` CLI) enables developers to create and manage apps on Tanzu Application Service. Healthwatch executes a continuous test suite to validate the core functions of the `cf` CLI.
+The Cloud Foundry Command Line Interface (`cf` CLI)
+enables developers to create and manage apps on Tanzu Application Service.
+Healthwatch executes a continuous test suite to validate the core functions of the `cf` CLI.
 
 The table below provides information about the `cf` CLI health smoke tests and the metrics that are generated for these tests.
 
@@ -57,17 +60,21 @@ The table below provides information about the `cf` CLI health smoke tests and t
 | `pas_sli_task_failures_total{task="start"}`  | Total number of failures for a `cf start` command on PAS   |
 | `pas_sli_task_failures_total{task="stop"}`   | Total number of failures for a `cf stop` command on PAS    |
 
-### PAS
+### <a id='pas'></a>PAS Exporter
 
-healthwatch_pasExporter_counterConversion_seconds
-healthwatch_pasExporter_evictedMetrics
-healthwatch_pasExporter_gaugeConversion_seconds
-healthwatch_pasExporter_ingressLatency_seconds
-healthwatch_pasExporter_ingress_envelopes
-healthwatch_pasExporter_status
+These metrics correspond to the health of the PAS Exporter process,
+which is a process that takes metrics from the Firehose
+and makes them accessible on a Prometheus-compatible metrics endpoint.
 
+| Metric                                              | Description                                                                     |
+|-----------------------------------------------------|---------------------------------------------------------------------------------|
+| `healthwatch_pasExporter_counterConversion_seconds` | Number of seconds it took to convert a counter envelope to a Prometheus counter |
+| `healthwatch_pasExporter_evictedMetrics`            | Number of metrics evicted from exporter cache                                   |
+| `healthwatch_pasExporter_gaugeConversion_seconds`   | Number of seconds it took to convert a gauge envelope to a Prometheus gauge     |
+| `healthwatch_pasExporter_ingressLatency_seconds`    | Number of seconds it took process a batch of Loggregator envelopes              |
+| `healthwatch_pasExporter_ingress_envelopes`         | Number of envelopes received by observability metrics agent                     |
+| `healthwatch_pasExporter_status`                    | Exporter status, a 1 indicates the exporter is running and healthy              |
 
-<p class="note"><strong>Note</strong>: The Cloud Foundry CLI health checks each have a timeout of 2 minutes (default value).</p>
 
 ### <a id='pks-cli'></a>PKS CLI Health
 
@@ -85,15 +92,20 @@ PKS CLI Health smoke tests and the metrics that are generated for these tests.
 | `pks_sli_task_failures_total{task="login"}`           | Total number of failures for a `pks login` command           |
 | `pks_sli_task_failures_total{task="plans"}`           | Total number of failures for a `pks plans` command           |
 
+
 ### <a id='bosh-health'></a>BOSH Health
 
 BOSH is the technology behind Ops Manager to manage the
-VMs deployed. If the BOSH Director is not responsive or functional, BOSH-managed VMs lose their resiliency. Healthwatch executes a continuous test suite
+VMs deployed. If the BOSH Director is not responsive or functional, BOSH-managed VMs lose their resiliency.
+Healthwatch executes a continuous test suite
 to validate the functionality of BOSH director.
 
 The table below provides information about the metrics that are generated.
 
-<p class="note"><strong>Note</strong>: Healthwatch deploys and deletes a VM named <code>bosh-health-exporter</code> as part of this test suite.</p>
+<p class="note">
+  <strong>Note</strong>:
+  Healthwatch deploys and deletes a VM named <code>bosh-health-exporter</code> as part of this test suite.
+</p>
 
 | Metric                                                     | Description                                                                                   |
 |------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
@@ -114,30 +126,14 @@ The table below provides information about the metrics that are generated.
 
 ### <a id='cert-expiration'></a>Certificate Expiration Monitoring
 
-Healthwatch exposes metrics about the expiration of certificates. For more information, see [here](common-configurations/certificate-monitoring.html).
+Healthwatch exposes metrics about the expiration of certificates.
+For more information, see [here](common-configurations/certificate-monitoring.html).
 
 The table below provides information about the metrics that are generated.
 
-<table class="nice">
-<tr>
-  <th>Test</th>
-  <th>Metric</th>
-  <th>Frequency</th>
-  <th>Description</th>
-</tr>
-<tr>
-  <td>Certificate time to expire</td>
-  <td><code>ssl_certificate_expiry_seconds{exported_instance=~".*"}</code></td>
-  <td>1 min</td>
-  <td>How long in seconds until certain certificate(s) expire.</td>
-</tr>
-</table>
-
-
-probe_http_ssl
-probe_ssl_earliest_cert_expiry
-probe_ssl_last_chain_expiry_timestamp_seconds
-ssl_certificate_expiry_seconds{exported_instance=~".*"}
+| Metric                                                    | Description                                       |
+|-----------------------------------------------------------|---------------------------------------------------|
+| `ssl_certificate_expiry_seconds{exported_instance=~".*"}` | Duration in seconds until the certificate expires |
 
 
 ### <a id='blackbox'></a>Canary URL Health
@@ -174,56 +170,62 @@ along with the response time metrics.
 | `probe_success`                                 | Displays whether or not the probe was a success                                    |
 | `probe_tls_version_info`                        | Returns the TLS version used, or NaN when unknown                                  |
 
-### Prometheus Exposition
 
-healthwatch_prometheusExpositionLatency_seconds
-healthwatch_prometheusExposition_expiredMetrics
-healthwatch_prometheusExposition_histogramMapConversion
-healthwatch_prometheusExposition_metricMapConversion
-healthwatch_prometheusExposition_metricSorting
+### <a id="prometheus-exposition"></a>Prometheus Exposition
 
-
-
-### SVM Forwarder
-
-failed_scrapes_total
-last_total_attempted_scrapes
-last_total_failed_scrapes
-last_total_scrape_duration
-scrape_targets_total
+| Metric                                                    | Description                                                        |
+|-----------------------------------------------------------|--------------------------------------------------------------------|
+| `healthwatch_prometheusExpositionLatency_seconds`         | Number of seconds it took to render Prometheus scrape page         |
+| `healthwatch_prometheusExposition_expiredMetrics`         | Number of metrics expired from exporter cache                      |
+| `healthwatch_prometheusExposition_histogramMapConversion` | Time it takes to convert histogram collection to a map             |
+| `healthwatch_prometheusExposition_metricMapConversion`    | Time it takes to convert metrics collection to a map               |
+| `healthwatch_prometheusExposition_metricSorting`          | Time it takes to sort metrics when rendering Prometheus exposition |
 
 
-### SVMs
+### <a id="svm-forwarder"></a>SVM Forwarder
+
+| Metric                         | Description                                                               |
+|--------------------------------|---------------------------------------------------------------------------|
+| `failed_scrapes_total`         | Total number of failed scrapes for the target source_id.                  |
+| `last_total_attempted_scrapes` | Count of attempted scrapes during last round of scraping.                 |
+| `last_total_failed_scrapes`    | Count of failed scrapes during last round of scraping.                    |
+| `last_total_scrape_duration`   | Time in milliseconds to scrape all targets in last round of scraping.     |
+| `scrape_targets_total`         | Total number of scrape targets identified from prom scraper config files. |
+
+
+### <a id="svms"></a>SVMs
 
 The following metrics are Healthwatch 1.x metrics
 that are still available for use by turning on the SVM Forwarder.
 See the [Release Notes](./release-notes.html#2-0-1) for more information.
 
-Diego_AvailableFreeChunksDisk
-Diego_AvailableFreeChunks
-Diego_LRPsAdded_1H
-Diego_TotalAvailableContainerCapacity_5M
-Diego_TotalPercentageAvailableDiskCapacity_5M
-Diego_TotalAvailableMemoryCapacity_5M
-Diego_TotalPercentageAvailableContainerCapacity_5M
-Diego_TotalAvailableDiskCapacity_5M
-Doppler_MessagesAverage_1M
-Firehose_LossRate_1H
-Firehose_LossRate_1M
-SyslogDrain_RLP_LossRate_1M
-SyslogAgent_LossRate_1M
-uaa_throughput_rate
-Diego_TotalPercentageAvailableMemoryCapacity_5M
-health_check_CanaryApp_available
-health_check_CanaryApp_responseTime
-health_check_bosh_director_success                       | BOSH SLI test status, 1 indicates success
-health_check_cliCommand_login
-health_check_cliCommand_push
-health_check_cliCommand_pushTime
-health_check_cliCommand_start
-health_check_cliCommand_logs
-health_check_cliCommand_stop
-health_check_cliCommand_delete
-health_check_cliCommand_probe_count
-health_check_cliCommand_success
-bosh_deployment
+| Metric                                               | Description                                                                                         |
+|------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `Diego_AppsDomainSynced`                             | ?                                                                                                   |
+| `Diego_AvailableFreeChunksDisk`                      | Diego Available Free Chunks of Disk                                                                 |
+| `Diego_AvailableFreeChunks`                          | Diego Available Free Chunks of Memory                                                               |
+| `Diego_LRPsAdded_1H`                                 | Rate of Change in Running App Instances                                                             |
+| `Diego_TotalAvailableDiskCapacity_5M`                | Remaining Cell Disk Available                                                                       |
+| `Diego_TotalAvailableMemoryCapacity_5M`              | Remaining Cell Memory Available                                                                     |
+| `Diego_TotalPercentageAvailableContainerCapacity_5M` | Diego Container Capacity                                                                            |
+| `Diego_TotalPercentageAvailableDiskCapacity_5M`      | Diego Cell Disk                                                                                     |
+| `Diego_TotalPercentageAvailableMemoryCapacity_5M`    | Diego Cell Memory                                                                                   |
+| `Doppler_MessagesAverage_1M`                         | Doppler Message Rate Average                                                                        |
+| `Firehose_LossRate_1H`                               | Log Transport Loss Rate                                                                             |
+| `Firehose_LossRate_1M`                               | Log Transport Loss Rate                                                                             |
+| `SyslogAgent_LossRate_1M`                            | Syslog Agent Loss Rate                                                                              |
+| `SyslogDrain_RLP_LossRate_1M`                        | Reverse Log Proxy Loss Rate                                                                         |
+| `bosh_deployment`                                    |                                                                                                     |
+| `health_check_bosh_director_success`                 | BOSH SLI test status, 1 indicates success                                                           |
+| `health_check_CanaryApp_available`                   | Canary App Availability                                                                             |
+| `health_check_CanaryApp_responseTime`                | Canary App Response Time                                                                            |
+| `health_check_cliCommand_delete`                     | Can CF Delete                                                                                       |
+| `health_check_cliCommand_login`                      | Can CF Login                                                                                        |
+| `health_check_cliCommand_logs`                       | Can Receive Logs                                                                                    |
+| `health_check_cliCommand_probe_count`                | Number of Healthwatch CLI Command Health probe assessments completed in the measured time interval. |
+| `health_check_cliCommand_pushTime`                   | CF Push Time                                                                                        |
+| `health_check_cliCommand_push`                       | Can CF Push                                                                                         |
+| `health_check_cliCommand_start`                      | Can CF Start                                                                                        |
+| `health_check_cliCommand_stop`                       | Can CF Stop                                                                                         |
+| `health_check_cliCommand_success`                    | Overall success of the CF CLI SLI tests                                                             |
+| `uaa_throughput_rate`                                | UAA Throughput Rate                                                                                 |

--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -97,6 +97,35 @@ The table below provides information about the `cf` CLI health smoke tests and t
 </tr>
 </table>
 
+
+| Test            | Metric               | Frequency | Description                             |
+|-----------------|----------------------|-----------|-----------------------------------------|
+| Total test runs | `pas_sli_runs_total` | 5 min     | Number of times the test suite has run. |
+|                 |                      |           |                                         |
+|                 |                      |           |                                         |
+
+pas_sli_durations_seconds_bucket
+pas_sli_durations_seconds_count
+pas_sli_durations_seconds_sum
+pas_sli_exporter_status
+pas_sli_failures_total
+pas_sli_run_duration_seconds
+pas_sli_runs_total
+pas_sli_task_duration_seconds_bucket
+pas_sli_task_duration_seconds_count
+pas_sli_task_duration_seconds_sum
+pas_sli_task_failures_total{task="delete"}
+pas_sli_task_failures_total{task="login"}
+pas_sli_task_failures_total{task="logs"}
+pas_sli_task_failures_total{task="push"}
+pas_sli_task_failures_total{task="setEnv"}
+pas_sli_task_failures_total{task="start"}
+pas_sli_task_failures_total{task="stop"}
+pas_sli_task_run_duration_seconds{task="push"}
+pas_sli_task_runs_total
+
+
+
 <p class="note"><strong>Note</strong>: The Cloud Foundry CLI health checks each have a timeout of 2 minutes (default value).</p>
 
 ### <a id='pks-cli'></a>PKS CLI Health
@@ -173,6 +202,25 @@ PKS CLI Health smoke tests and the metrics that are generated for these tests.
 </table>
 
 
+pks_sli_duration_seconds_bucket
+pks_sli_duration_seconds_count
+pks_sli_duration_seconds_sum
+pks_sli_exporter_status
+pks_sli_failures_total
+pks_sli_number_of_clusters
+pks_sli_run_duration_seconds
+pks_sli_runs_total
+pks_sli_task_duration_seconds_bucket
+pks_sli_task_duration_seconds_count
+pks_sli_task_duration_seconds_sum
+pks_sli_task_failures_total{task="clusters"}
+pks_sli_task_failures_total{task="get-credentials"}
+pks_sli_task_failures_total{task="login"}
+pks_sli_task_failures_total{task="plans"}
+pks_sli_task_run_duration_seconds{task="get-credentials"}
+pks_sli_task_runs_total
+
+
 ### <a id='bosh-health'></a>BOSH Health
 
 BOSH is the technology behind Ops Manager to manage the
@@ -241,6 +289,39 @@ The table below provides information about the metrics that are generated.
 <p class="note"><strong>Note</strong>: Healthwatch deploys and deletes a VM named <code>bosh-health-exporter</code> as part of this test suite.</p>
 
 
+bosh_deployment
+bosh_deployments_status
+bosh_sli_duration_seconds_bucket
+bosh_sli_duration_seconds_count
+bosh_sli_duration_seconds_sum
+bosh_sli_exporter_status
+bosh_sli_failures_total
+bosh_sli_run_duration_seconds
+bosh_sli_runs_total
+bosh_sli_task_duration_seconds_bucket
+bosh_sli_task_duration_seconds_count
+bosh_sli_task_duration_seconds_sum
+bosh_sli_task_failures_total{task="delete"}
+bosh_sli_task_failures_total{task="deploy"}
+bosh_sli_task_failures_total{task="deployments"}
+bosh_sli_task_failures_total{task="tasks"}
+bosh_sli_task_run_duration_seconds
+bosh_sli_task_runs_total
+health_bosh_deployment_probe_count
+health_check_bosh_director_probe_availability
+health_check_bosh_director_probe_count
+health_check_bosh_director_success
+healthwatch_boshExporter_ingressLatency_seconds_bucket
+healthwatch_boshExporter_ingressLatency_seconds_count
+healthwatch_boshExporter_ingressLatency_seconds_sum
+healthwatch_boshExporter_ingress_envelopes
+healthwatch_boshExporter_metricConversion_seconds_bucket
+healthwatch_boshExporter_metricConversion_seconds_count
+healthwatch_boshExporter_metricConversion_seconds_sum
+healthwatch_boshExporter_status
+ingestor_ingested_boshSystemMetrics
+
+
 ### <a id='cert-expiration'></a>Certificate Expiration Monitoring
 
 Healthwatch exposes metrics about the expiration of certificates. For more information, see [here](common-configurations/certificate-monitoring.html).
@@ -261,6 +342,12 @@ The table below provides information about the metrics that are generated.
   <td>How long in seconds until certain certificate(s) expire.</td>
 </tr>
 </table>
+
+
+probe_http_ssl
+probe_ssl_earliest_cert_expiry
+probe_ssl_last_chain_expiry_timestamp_seconds
+ssl_certificate_expiry_seconds{exported_instance=~".*"}
 
 
 ### <a id='blackbox'></a>Canary URL Health
@@ -290,3 +377,21 @@ along with the response time metrics.
 </tr>
 </table>
 
+
+probe_dns_lookup_time_seconds
+probe_duration_seconds
+probe_failed_due_to_regex
+probe_http_content_length
+probe_http_duration_seconds
+probe_http_last_modified_timestamp_seconds
+probe_http_redirects
+probe_http_ssl
+probe_http_status_code
+probe_http_uncompressed_body_length
+probe_http_version
+probe_ip_addr_hash
+probe_ip_protocol
+probe_ssl_earliest_cert_expiry
+probe_ssl_last_chain_expiry_timestamp_seconds
+probe_success{instance=~".*"}
+probe_tls_version_info

--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -104,9 +104,9 @@ The table below provides information about the `cf` CLI health smoke tests and t
 |                 |                      |           |                                         |
 |                 |                      |           |                                         |
 
-pas_sli_durations_seconds_bucket
-pas_sli_durations_seconds_count
-pas_sli_durations_seconds_sum
+pas_sli_duration_seconds_bucket
+pas_sli_duration_seconds_count
+pas_sli_duration_seconds_sum
 pas_sli_exporter_status
 pas_sli_failures_total
 pas_sli_run_duration_seconds
@@ -124,6 +124,15 @@ pas_sli_task_failures_total{task="stop"}
 pas_sli_task_run_duration_seconds{task="push"}
 pas_sli_task_runs_total
 
+
+### PAS
+
+healthwatch_pasExporter_counterConversion_seconds
+healthwatch_pasExporter_evictedMetrics
+healthwatch_pasExporter_gaugeConversion_seconds
+healthwatch_pasExporter_ingressLatency_seconds
+healthwatch_pasExporter_ingress_envelopes
+healthwatch_pasExporter_status
 
 
 <p class="note"><strong>Note</strong>: The Cloud Foundry CLI health checks each have a timeout of 2 minutes (default value).</p>
@@ -289,37 +298,31 @@ The table below provides information about the metrics that are generated.
 <p class="note"><strong>Note</strong>: Healthwatch deploys and deletes a VM named <code>bosh-health-exporter</code> as part of this test suite.</p>
 
 
-bosh_deployment
-bosh_deployments_status
-bosh_sli_duration_seconds_bucket
-bosh_sli_duration_seconds_count
-bosh_sli_duration_seconds_sum
-bosh_sli_exporter_status
-bosh_sli_failures_total
-bosh_sli_run_duration_seconds
-bosh_sli_runs_total
-bosh_sli_task_duration_seconds_bucket
-bosh_sli_task_duration_seconds_count
-bosh_sli_task_duration_seconds_sum
-bosh_sli_task_failures_total{task="delete"}
-bosh_sli_task_failures_total{task="deploy"}
-bosh_sli_task_failures_total{task="deployments"}
-bosh_sli_task_failures_total{task="tasks"}
-bosh_sli_task_run_duration_seconds
-bosh_sli_task_runs_total
-health_bosh_deployment_probe_count
-health_check_bosh_director_probe_availability
-health_check_bosh_director_probe_count
-health_check_bosh_director_success
-healthwatch_boshExporter_ingressLatency_seconds_bucket
-healthwatch_boshExporter_ingressLatency_seconds_count
-healthwatch_boshExporter_ingressLatency_seconds_sum
-healthwatch_boshExporter_ingress_envelopes
-healthwatch_boshExporter_metricConversion_seconds_bucket
-healthwatch_boshExporter_metricConversion_seconds_count
-healthwatch_boshExporter_metricConversion_seconds_sum
-healthwatch_boshExporter_status
-ingestor_ingested_boshSystemMetrics
+bosh_deployments_status                                  | Bosh Deployments status, a 1 indicates a deployment is occurring on the director
+bosh_sli_duration_seconds_bucket                         | Number of seconds it took for the SLI test suite to run, grouped by duration
+bosh_sli_duration_seconds_count                          | Total number of metrics in all the buckets
+bosh_sli_duration_seconds_sum                            | Total value of the metrics in all the buckets
+bosh_sli_exporter_status                                 | Exporter status, a 1 indicates the exporter is running and healthy
+bosh_sli_failures_total                                  | Total number of failures of the SLI test suite
+bosh_sli_run_duration_seconds                            | Number of seconds it took for the SLI test suite to run
+bosh_sli_runs_total                                      | Total number of runs of the SLI test suite. Use bosh_sli_failures_total / bosh_sli_runs_total to get failure rate.
+bosh_sli_task_duration_seconds_bucket                    | Number of seconds it took for a particular task to run, grouped by duration
+bosh_sli_task_duration_seconds_count                     | Total number of metrics in all the buckets
+bosh_sli_task_duration_seconds_sum                       | Total value of the metrics in all the buckets
+bosh_sli_task_failures_total{task="delete"}              | Total number of failures for an SLI "delete" task
+bosh_sli_task_failures_total{task="deploy"}              | Total number of failures for an SLI "deploy" task
+bosh_sli_task_failures_total{task="deployments"}         | Total number of failures for an SLI "deployments" task
+bosh_sli_task_failures_total{task="tasks"}               | Total number of failures for an SLI "tasks" task
+bosh_sli_task_run_duration_seconds                       | Number of seconds it took for a particular task to run
+bosh_sli_task_runs_total                                 | Total number of runs for a particular SLI task. Use bosh_sli_task_failures_total / bosh_sli_task_runs_total to get failure rate.
+healthwatch_boshExporter_ingressLatency_seconds_bucket   | Number of seconds it took to process a batch of Loggregator envelopes, grouped by latency
+healthwatch_boshExporter_ingressLatency_seconds_count    | Total number of metrics in all the buckets
+healthwatch_boshExporter_ingressLatency_seconds_sum      | Total value of the metrics in all the buckets
+healthwatch_boshExporter_ingress_envelopes               | Number of envelopes received by observability metrics agent
+healthwatch_boshExporter_metricConversion_seconds_bucket | Number of seconds it took to convert a bosh metric to a Prometheus gauge, grouped by duration
+healthwatch_boshExporter_metricConversion_seconds_count  | Total number of metrics in all the buckets
+healthwatch_boshExporter_metricConversion_seconds_sum    | Total value of the metrics in all the buckets
+healthwatch_boshExporter_status                          | Exporter status, a 1 indicates the exporter is running and healthy
 
 
 ### <a id='cert-expiration'></a>Certificate Expiration Monitoring
@@ -378,20 +381,92 @@ along with the response time metrics.
 </table>
 
 
-probe_dns_lookup_time_seconds
-probe_duration_seconds
-probe_failed_due_to_regex
-probe_http_content_length
-probe_http_duration_seconds
-probe_http_last_modified_timestamp_seconds
-probe_http_redirects
-probe_http_ssl
-probe_http_status_code
-probe_http_uncompressed_body_length
-probe_http_version
-probe_ip_addr_hash
-probe_ip_protocol
-probe_ssl_earliest_cert_expiry
-probe_ssl_last_chain_expiry_timestamp_seconds
-probe_success{instance=~".*"}
-probe_tls_version_info
+
+
+
+
+`probe_dns_additional_rrs`                      | Returns number of entries in the additional resource record list
+`probe_dns_answer_rrs`                          | Returns number of entries in the answer resource record list
+`probe_dns_authority_rrs`                       | Returns number of entries in the authority resource record list
+`probe_dns_duration_seconds`                    | Duration of DNS request by phase
+`probe_dns_lookup_time_seconds`                 | Returns the time taken for probe dns lookup in seconds
+`probe_dns_serial`                              | Returns the serial number of the zone
+`probe_duration_seconds`                        | Returns how long the probe took to complete in seconds
+`probe_failed_due_to_regex`                     | Indicates if probe failed due to regex
+`probe_http_content_length`                     | Length of http content response
+`probe_http_duration_seconds`                   | Duration of http request by phase, summed over all redirects
+`probe_http_last_modified_timestamp_seconds`    | Returns the Last-Modified HTTP response header in unixtime
+`probe_http_redirects`                          | The number of redirects
+`probe_http_ssl`                                | Indicates if SSL was used for the final redirect
+`probe_http_status_code`                        | Response HTTP status code
+`probe_http_uncompressed_body_length`           | Length of uncompressed response body
+`probe_http_version`                            | Returns the version of HTTP of the probe response
+`probe_icmp_duration_seconds`                   | Duration of icmp request by phase
+`probe_icmp_reply_hop_limit`                    | Replied packet hop limit (TTL for ipv4)
+`probe_ip_addr_hash`                            | Specifies the hash of IP address. It's useful to detect if the IP address changes.
+`probe_ip_protocol`                             | Specifies whether probe ip protocol is IP4 or IP6
+`probe_ssl_earliest_cert_expiry`                | Returns earliest SSL cert expiry in unixtime
+`probe_ssl_last_chain_expiry_timestamp_seconds` | Returns last SSL chain expiry in unixtime
+`probe_ssl_last_chain_info`                     | Contains SSL leaf certificate information
+`probe_success`                                 | Displays whether or not the probe was a success
+`probe_tls_version_info`                        | Returns the TLS version used, or NaN when unknown
+
+
+
+
+\.new(Gauge|Counter|Const)
+
+
+### Prometheus Exposition
+
+healthwatch_prometheusExpositionLatency_seconds
+healthwatch_prometheusExposition_expiredMetrics
+healthwatch_prometheusExposition_histogramMapConversion
+healthwatch_prometheusExposition_metricMapConversion
+healthwatch_prometheusExposition_metricSorting
+
+
+
+### SVM Forwarder
+
+failed_scrapes_total
+last_total_attempted_scrapes
+last_total_failed_scrapes
+last_total_scrape_duration
+scrape_targets_total
+
+
+### SVMs
+
+The following metrics are Healthwatch 1.x metrics
+that are still available for use by turning on the SVM Forwarder.
+See the [Release Notes](./release-notes.html#2-0-1) for more information.
+
+Diego_AvailableFreeChunksDisk
+Diego_AvailableFreeChunks
+Diego_LRPsAdded_1H
+Diego_TotalAvailableContainerCapacity_5M
+Diego_TotalPercentageAvailableDiskCapacity_5M
+Diego_TotalAvailableMemoryCapacity_5M
+Diego_TotalPercentageAvailableContainerCapacity_5M
+Diego_TotalAvailableDiskCapacity_5M
+Doppler_MessagesAverage_1M
+Firehose_LossRate_1H
+Firehose_LossRate_1M
+SyslogDrain_RLP_LossRate_1M
+SyslogAgent_LossRate_1M
+uaa_throughput_rate
+Diego_TotalPercentageAvailableMemoryCapacity_5M
+health_check_CanaryApp_available
+health_check_CanaryApp_responseTime
+health_check_bosh_director_success                       | BOSH SLI test status, 1 indicates success
+health_check_cliCommand_login
+health_check_cliCommand_push
+health_check_cliCommand_pushTime
+health_check_cliCommand_start
+health_check_cliCommand_logs
+health_check_cliCommand_stop
+health_check_cliCommand_delete
+health_check_cliCommand_probe_count
+health_check_cliCommand_success
+bosh_deployment

--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -6,43 +6,86 @@ owner: Healthwatch
 This topic lists the metrics created by Healthwatch,
 including Tanzu Application Service Exporter and Enterprise PKS Exporter.
 
+Prometheus scrapes the `/metrics` endpoint for each of the Exporters.
+The frequency with which it scrapes can be configured in the Healthwatch tile.
+
 <p class="note"><strong>Note</strong>: For external monitoring consumers,
   Healthwatch exposes the metrics that it creates through scrapable metrics endpoints.
   The metrics endpoints are secured by mTLS certs generated using Ops Manager CA cert.
 </p>
 
-## <a id='sli'></a>Platform Service Level Indicators
+<p class="note">
+  <strong>Note</strong>:
+  The VM names for each of these sections are in parenthesis.
+  All of these vms are deployed from either the PAS Exporter Tile
+  or the PKS Exporter Tile unless otherwise mentioned.
+</p>
+
+## <a id='bosh-sli'></a> Bosh Service Level Indicator Metrics
+
+BOSH is the technology behind Ops Manager to manage the
+VMs deployed. If the BOSH Director is not responsive or functional, BOSH-managed VMs lose their resiliency.
+Healthwatch executes a continuous test suite
+to validate the functionality of BOSH director.
+
+There are three exporters that handle SLI metrics for BOSH,
+the Bosh Deployments Exporter, the Bosh Health Exporter, and the PKS Exporter.
+
+### <a id='bosh-deployments-exporter'></a> Bosh Deployments Exporter (bosh-deployments-exporter)
+
+The Bosh Deployments Exporter periodically checks
+to see if any BOSH Deployments other than the one created by the Bosh Health Exporter are running.
+
+| Metric                                                                                | Description                                                                                                                                                                                                              |
+|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bosh_deployments_status`                                                             | Bosh Deployments status, a 1 indicates a deployment is occurring on the director                                                                                                                                         |
+| `bosh_sli_duration_seconds_bucket{exported_job="bosh-deployments-exporter"}`          | Number of seconds it took for the SLI test suite to run, grouped by duration                                                                                                                                             |
+| `bosh_sli_duration_seconds_count{exported_job="bosh-deployments-exporter"}`           | Total number of metrics in all the buckets                                                                                                                                                                               |
+| `bosh_sli_duration_seconds_sum{exported_job="bosh-deployments-exporter"}`             | Total value of the metrics in all the buckets                                                                                                                                                                            |
+| `bosh_sli_exporter_status{exported_job="bosh-deployments-exporter"}`                  | Exporter status, a 1 indicates the exporter is running and healthy                                                                                                                                                       |
+| `bosh_sli_failures_total{exported_job="bosh-deployments-exporter"}`                   | Total number of failures of the SLI test suite                                                                                                                                                                           |
+| `bosh_sli_run_duration_seconds{exported_job="bosh-deployments-exporter"}`             | Number of seconds it took for the SLI test suite to run                                                                                                                                                                  |
+| `bosh_sli_runs_total{exported_job="bosh-deployments-exporter"}`                       | Total number of runs of the SLI test suite. Use `bosh_sli_failures_total{exported_job="bosh-deployments-exporter"}` / `bosh_sli_runs_total{exported_job="bosh-deployments-exporter"}` to get failure rate.               |
+| `bosh_sli_task_duration_seconds_bucket{exported_job="bosh-deployments-exporter"}`     | Number of seconds it took for a particular task to run, grouped by duration                                                                                                                                              |
+| `bosh_sli_task_duration_seconds_count{exported_job="bosh-deployments-exporter"}`      | Total number of metrics in all the buckets                                                                                                                                                                               |
+| `bosh_sli_task_duration_seconds_sum{exported_job="bosh-deployments-exporter"}`        | Total value of the metrics in all the buckets                                                                                                                                                                            |
+| `bosh_sli_task_run_duration_seconds{exported_job="bosh-deployments-exporter"}`        | Number of seconds it took for a particular task to run                                                                                                                                                                   |
+| `bosh_sli_task_runs_total{exported_job="bosh-deployments-exporter"}`                  | Total number of runs for a particular SLI task. Use `bosh_sli_task_failures_total{exported_job="bosh-deployments-exporter"}` / `bosh_sli_task_runs_total{exported_job="bosh-deployments-exporter"}` to get failure rate. |
+| `bosh_sli_task_failures_total{exported_job="bosh-deployments-exporter",task="tasks"}` | Total number of failures for a `bosh tasks` command                                                                                                                                                                      |
+
+### <a id='bosh-health-exporter'></a> Bosh Health Exporter (bosh-health-exporter)
+
+The Bosh Health Exporter periodically creates and deletes a BOSH deployment.
+
+<p class="note">
+  <strong>Note</strong>:
+  The BOSH Health Exporter deploys and deletes a VM named <code>bosh-health-exporter</code> as part of this test suite.
+</p>
+
+| Metric                                                                                 | Description                                                                                                                                                                                        |
+|----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bosh_sli_duration_seconds_bucket{exported_job="bosh-health-exporter"}`                | Number of seconds it took for the SLI test suite to run, grouped by duration                                                                                                                       |
+| `bosh_sli_duration_seconds_count{exported_job="bosh-health-exporter"}`                 | Total number of metrics in all the buckets                                                                                                                                                         |
+| `bosh_sli_duration_seconds_sum{exported_job="bosh-health-exporter"}`                   | Total value of the metrics in all the buckets                                                                                                                                                      |
+| `bosh_sli_exporter_status{exported_job="bosh-health-exporter"}`                        | Exporter status, a 1 indicates the exporter is running and healthy                                                                                                                                 |
+| `bosh_sli_failures_total{exported_job="bosh-health-exporter"}`                         | Total number of failures of the SLI test suite                                                                                                                                                     |
+| `bosh_sli_run_duration_seconds{exported_job="bosh-health-exporter"}`                   | Number of seconds it took for the SLI test suite to run                                                                                                                                            |
+| `bosh_sli_runs_total{exported_job="bosh-health-exporter"}`                             | Total number of runs of the SLI test suite. Use `bosh_sli_failures_total{exported_job="bosh-health-exporter"}` / `bosh_sli_runs_total{exported_job="bosh-health-exporter"}` to get failure rate.   |
+| `bosh_sli_task_duration_seconds_bucket{exported_job="bosh-health-exporter"}`           | Number of seconds it took for a particular task to run, grouped by duration                                                                                                                        |
+| `bosh_sli_task_duration_seconds_count{exported_job="bosh-health-exporter"}`            | Total number of metrics in all the buckets                                                                                                                                                         |
+| `bosh_sli_task_duration_seconds_sum{exported_job="bosh-health-exporter"}`              | Total value of the metrics in all the buckets                                                                                                                                                      |
+| `bosh_sli_task_run_duration_seconds{exported_job="bosh-health-exporter"}`              | Number of seconds it took for a particular task to run                                                                                                                                             |
+| `bosh_sli_task_runs_total{exported_job="bosh-health-exporter"}`                        | Total number of runs for a particular SLI task. Use `bosh_sli_task_failures{exported_job="bosh-health-exporter"}` / `bosh_sli_task_runs{exported_job="bosh-health-exporter"}` to get failure rate. |
+| `bosh_sli_task_failures_total{exported_job="bosh-health-exporter",task="delete"}`      | Total number of failures for a `bosh delete-deployment` command                                                                                                                                    |
+| `bosh_sli_task_failures_total{exported_job="bosh-health-exporter",task="deploy"}`      | Total number of failures for a `bosh deploy` command                                                                                                                                               |
+| `bosh_sli_task_failures_total{exported_job="bosh-health-exporter",task="deployments"}` | Total number of failures for a `bosh deployments` command                                                                                                                                          |
+
+## <a id='platform-sli'></a> Platform Service Level Indicators
 
 Healthwatch generates metrics that describe the health of several platform components.
 These metrics can be used to calculate percent availability and error budgets.
 
-### <a id='sli-tests'></a>SLI Tests
-
-We have a generic underlying component in our code called the SLI Test Runner
-which can be configured to run tasks that will provide Service Level Indicators
-for command line applications and processes. Thus, you will see a pattern emerge
-between certain metrics (`bosh_sli_...`, `pas_sli_...`, `pks_sli_...`).
-Here are the ones that `bosh`, `pas`, and `pks` should all have in common.
-
-| Metric                                                  | Description                                                                                                                          |
-|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `COMPONENT_deployments_status`                          | Bosh Deployments status, a 1 indicates a deployment is occurring on the director                                                     |
-| `COMPONENT_sli_duration_seconds_bucket`                 | Number of seconds it took for the SLI test suite to run, grouped by duration                                                         |
-| `COMPONENT_sli_duration_seconds_count`                  | Total number of metrics in all the buckets                                                                                           |
-| `COMPONENT_sli_duration_seconds_sum`                    | Total value of the metrics in all the buckets                                                                                        |
-| `COMPONENT_sli_exporter_status`                         | Exporter status, a 1 indicates the exporter is running and healthy                                                                   |
-| `COMPONENT_sli_failures_total`                          | Total number of failures of the SLI test suite                                                                                       |
-| `COMPONENT_sli_run_duration_seconds`                    | Number of seconds it took for the SLI test suite to run                                                                              |
-| `COMPONENT_sli_runs_total`                              | Total number of runs of the SLI test suite. Use `bosh_sli_failures_total` / `bosh_sli_runs_total` to get failure rate.               |
-| `COMPONENT_sli_task_duration_seconds_bucket`            | Number of seconds it took for a particular task to run, grouped by duration                                                          |
-| `COMPONENT_sli_task_duration_seconds_count`             | Total number of metrics in all the buckets                                                                                           |
-| `COMPONENT_sli_task_duration_seconds_sum`               | Total value of the metrics in all the buckets                                                                                        |
-| `COMPONENT_sli_task_run_duration_seconds`               | Number of seconds it took for a particular task to run                                                                               |
-| `COMPONENT_sli_task_runs_total`                         | Total number of runs for a particular SLI task. Use `bosh_sli_task_failures_total` / `bosh_sli_task_runs_total` to get failure rate. |
-
-Where `COMPONENT` is the platform or CLI tested (e.g. `bosh`, `pas`, `pks`).
-
-### <a id='cf-cli'></a>Cloud Foundry CLI Health
+### <a id='pas-sli-exporter'></a> PAS SLI Exporter (pas-sli-exporter)
 
 The Cloud Foundry Command Line Interface (`cf` CLI)
 enables developers to create and manage apps on Tanzu Application Service.
@@ -50,33 +93,29 @@ Healthwatch executes a continuous test suite to validate the core functions of t
 
 The table below provides information about the `cf` CLI health smoke tests and the metrics that are generated for these tests.
 
-| Metric                                       | Description                                                |
-|----------------------------------------------|------------------------------------------------------------|
-| `pas_sli_task_failures_total{task="delete"}` | Total number of failures for a `cf delete` command on PAS  |
-| `pas_sli_task_failures_total{task="login"}`  | Total number of failures for a `cf login` command on PAS   |
-| `pas_sli_task_failures_total{task="logs"}`   | Total number of failures for a `cf logs` command on PAS    |
-| `pas_sli_task_failures_total{task="push"}`   | Total number of failures for a `cf push` command on PAS    |
-| `pas_sli_task_failures_total{task="setEnv"}` | Total number of failures for a `cf set-env` command on PAS |
-| `pas_sli_task_failures_total{task="start"}`  | Total number of failures for a `cf start` command on PAS   |
-| `pas_sli_task_failures_total{task="stop"}`   | Total number of failures for a `cf stop` command on PAS    |
+| Metric                                       | Description                                                                                                            |
+|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `pas_sli_duration_seconds_bucket`            | Number of seconds it took for the SLI test suite to run, grouped by duration                                           |
+| `pas_sli_duration_seconds_count`             | Total number of metrics in all the buckets                                                                             |
+| `pas_sli_duration_seconds_sum`               | Total value of the metrics in all the buckets                                                                          |
+| `pas_sli_exporter_status`                    | Exporter status, a 1 indicates the exporter is running and healthy                                                     |
+| `pas_sli_failures_total`                     | Total number of failures of the SLI test suite                                                                         |
+| `pas_sli_run_duration_seconds`               | Number of seconds it took for the SLI test suite to run                                                                |
+| `pas_sli_runs_total`                         | Total number of runs of the SLI test suite. Use `pas_sli_failures_total` / `pas_sli_runs_total` to get failure rate.   |
+| `pas_sli_task_duration_seconds_bucket`       | Number of seconds it took for a particular task to run, grouped by duration                                            |
+| `pas_sli_task_duration_seconds_count`        | Total number of metrics in all the buckets                                                                             |
+| `pas_sli_task_duration_seconds_sum`          | Total value of the metrics in all the buckets                                                                          |
+| `pas_sli_task_run_duration_seconds`          | Number of seconds it took for a particular task to run                                                                 |
+| `pas_sli_task_runs_total`                    | Total number of runs for a particular SLI task. Use `pas_sli_task_failures` / `pas_sli_task_runs` to get failure rate. |
+| `pas_sli_task_failures_total{task="delete"}` | Total number of failures for a `cf delete` command on PAS                                                              |
+| `pas_sli_task_failures_total{task="login"}`  | Total number of failures for a `cf login` command on PAS                                                               |
+| `pas_sli_task_failures_total{task="logs"}`   | Total number of failures for a `cf logs` command on PAS                                                                |
+| `pas_sli_task_failures_total{task="push"}`   | Total number of failures for a `cf push` command on PAS                                                                |
+| `pas_sli_task_failures_total{task="setEnv"}` | Total number of failures for a `cf set-env` command on PAS                                                             |
+| `pas_sli_task_failures_total{task="start"}`  | Total number of failures for a `cf start` command on PAS                                                               |
+| `pas_sli_task_failures_total{task="stop"}`   | Total number of failures for a `cf stop` command on PAS                                                                |
 
-### <a id='pas'></a>PAS Exporter
-
-These metrics correspond to the health of the PAS Exporter process,
-which is a process that takes metrics from the Firehose
-and makes them accessible on a Prometheus-compatible metrics endpoint.
-
-| Metric                                              | Description                                                                     |
-|-----------------------------------------------------|---------------------------------------------------------------------------------|
-| `healthwatch_pasExporter_counterConversion_seconds` | Number of seconds it took to convert a counter envelope to a Prometheus counter |
-| `healthwatch_pasExporter_evictedMetrics`            | Number of metrics evicted from exporter cache                                   |
-| `healthwatch_pasExporter_gaugeConversion_seconds`   | Number of seconds it took to convert a gauge envelope to a Prometheus gauge     |
-| `healthwatch_pasExporter_ingressLatency_seconds`    | Number of seconds it took process a batch of Loggregator envelopes              |
-| `healthwatch_pasExporter_ingress_envelopes`         | Number of envelopes received by observability metrics agent                     |
-| `healthwatch_pasExporter_status`                    | Exporter status, a 1 indicates the exporter is running and healthy              |
-
-
-### <a id='pks-cli'></a>PKS CLI Health
+### <a id='pks-sli-exporter'></a> PKS SLI Exporter (pks-sli-exporter)
 
 The PKS Command Line Interface (PKS CLI) allows the operator to create and manage
 Kubernetes clusters. Healthwatch executes a continuous test suite
@@ -85,46 +124,26 @@ to validate the core functions of the PKS CLI.
 The table below provides information about the
 PKS CLI Health smoke tests and the metrics that are generated for these tests.
 
-| Metric                                                | Description                                                  |
-|-------------------------------------------------------|--------------------------------------------------------------|
-| `pks_sli_task_failures_total{task="clusters"}`        | Total number of failures for a `pks clusters` command        |
-| `pks_sli_task_failures_total{task="get-credentials"}` | Total number of failures for a `pks get-credentials` command |
-| `pks_sli_task_failures_total{task="login"}`           | Total number of failures for a `pks login` command           |
-| `pks_sli_task_failures_total{task="plans"}`           | Total number of failures for a `pks plans` command           |
+| Metric                                                | Description                                                                                                            |
+|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `pks_sli_duration_seconds_bucket`                     | Number of seconds it took for the SLI test suite to run, grouped by duration                                           |
+| `pks_sli_duration_seconds_count`                      | Total number of metrics in all the buckets                                                                             |
+| `pks_sli_duration_seconds_sum`                        | Total value of the metrics in all the buckets                                                                          |
+| `pks_sli_exporter_status`                             | Exporter status, a 1 indicates the exporter is running and healthy                                                     |
+| `pks_sli_failures_total`                              | Total number of failures of the SLI test suite                                                                         |
+| `pks_sli_run_duration_seconds`                        | Number of seconds it took for the SLI test suite to run                                                                |
+| `pks_sli_runs_total`                                  | Total number of runs of the SLI test suite. Use `pks_sli_failures_total` / `pks_sli_runs_total` to get failure rate.   |
+| `pks_sli_task_duration_seconds_bucket`                | Number of seconds it took for a particular task to run, grouped by duration                                            |
+| `pks_sli_task_duration_seconds_count`                 | Total number of metrics in all the buckets                                                                             |
+| `pks_sli_task_duration_seconds_sum`                   | Total value of the metrics in all the buckets                                                                          |
+| `pks_sli_task_run_duration_seconds`                   | Number of seconds it took for a particular task to run                                                                 |
+| `pks_sli_task_runs_total`                             | Total number of runs for a particular SLI task. Use `pks_sli_task_failures` / `pks_sli_task_runs` to get failure rate. |
+| `pks_sli_task_failures_total{task="clusters"}`        | Total number of failures for a `pks clusters` command                                                                  |
+| `pks_sli_task_failures_total{task="get-credentials"}` | Total number of failures for a `pks get-credentials` command                                                           |
+| `pks_sli_task_failures_total{task="login"}`           | Total number of failures for a `pks login` command                                                                     |
+| `pks_sli_task_failures_total{task="plans"}`           | Total number of failures for a `pks plans` command                                                                     |
 
-
-### <a id='bosh-health'></a>BOSH Health
-
-BOSH is the technology behind Ops Manager to manage the
-VMs deployed. If the BOSH Director is not responsive or functional, BOSH-managed VMs lose their resiliency.
-Healthwatch executes a continuous test suite
-to validate the functionality of BOSH director.
-
-The table below provides information about the metrics that are generated.
-
-<p class="note">
-  <strong>Note</strong>:
-  Healthwatch deploys and deletes a VM named <code>bosh-health-exporter</code> as part of this test suite.
-</p>
-
-| Metric                                                     | Description                                                                                   |
-|------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `bosh_deployments_status`                                  | Bosh Deployments status, a 1 indicates a deployment is occurring on the director              |
-| `bosh_sli_task_failures_total{task="delete"}`              | Total number of failures for `bosh delete` command                                            |
-| `bosh_sli_task_failures_total{task="deploy"}`              | Total number of failures for `bosh deploy` command                                            |
-| `bosh_sli_task_failures_total{task="deployments"}`         | Total number of failures for `bosh deployments` command                                       |
-| `bosh_sli_task_failures_total{task="tasks"}`               | Total number of failures for `bosh tasks` command                                             |
-| `healthwatch_boshExporter_ingressLatency_seconds_bucket`   | Number of seconds it took to process a batch of Loggregator envelopes, grouped by latency     |
-| `healthwatch_boshExporter_ingressLatency_seconds_count`    | Total number of metrics in all the buckets                                                    |
-| `healthwatch_boshExporter_ingressLatency_seconds_sum`      | Total value of the metrics in all the buckets                                                 |
-| `healthwatch_boshExporter_ingress_envelopes`               | Number of envelopes received by observability metrics agent                                   |
-| `healthwatch_boshExporter_metricConversion_seconds_bucket` | Number of seconds it took to convert a bosh metric to a Prometheus gauge, grouped by duration |
-| `healthwatch_boshExporter_metricConversion_seconds_count`  | Total number of metrics in all the buckets                                                    |
-| `healthwatch_boshExporter_metricConversion_seconds_sum`    | Total value of the metrics in all the buckets                                                 |
-| `healthwatch_boshExporter_status`                          | Exporter status, a 1 indicates the exporter is running and healthy                            |
-
-
-### <a id='cert-expiration'></a>Certificate Expiration Monitoring
+### <a id='cert-expiration-exporter'></a> Cert Expiration Exporter (cert-expiration-exporter)
 
 Healthwatch exposes metrics about the expiration of certificates.
 For more information, see [here](common-configurations/certificate-monitoring.html).
@@ -135,12 +154,16 @@ The table below provides information about the metrics that are generated.
 |-----------------------------------------------------------|---------------------------------------------------|
 | `ssl_certificate_expiry_seconds{exported_instance=~".*"}` | Duration in seconds until the certificate expires |
 
-
-### <a id='blackbox'></a>Canary URL Health
+### <a id='tsdb'></a> TSDB (tsdb)
 
 App availability and responsiveness issues can significantly impact the experience of end users.
 Healthwatch allows operators to configure Canary URLs in the tile and expose whether the URL is running or not,
 along with the response time metrics.
+
+<p class="note">
+  <strong>Note</strong>:
+  These metrics are created by the blackbox exporter job on the TSDB VM in the Healthwatch deployment.
+</p>
 
 | Metric                                          | Description                                                                        |
 |-------------------------------------------------|------------------------------------------------------------------------------------|
@@ -170,33 +193,11 @@ along with the response time metrics.
 | `probe_success`                                 | Displays whether or not the probe was a success                                    |
 | `probe_tls_version_info`                        | Returns the TLS version used, or NaN when unknown                                  |
 
-
-### <a id="prometheus-exposition"></a>Prometheus Exposition
-
-| Metric                                                    | Description                                                        |
-|-----------------------------------------------------------|--------------------------------------------------------------------|
-| `healthwatch_prometheusExpositionLatency_seconds`         | Number of seconds it took to render Prometheus scrape page         |
-| `healthwatch_prometheusExposition_expiredMetrics`         | Number of metrics expired from exporter cache                      |
-| `healthwatch_prometheusExposition_histogramMapConversion` | Time it takes to convert histogram collection to a map             |
-| `healthwatch_prometheusExposition_metricMapConversion`    | Time it takes to convert metrics collection to a map               |
-| `healthwatch_prometheusExposition_metricSorting`          | Time it takes to sort metrics when rendering Prometheus exposition |
-
-
-### <a id="svm-forwarder"></a>SVM Forwarder
-
-| Metric                         | Description                                                              |
-|--------------------------------|--------------------------------------------------------------------------|
-| `failed_scrapes_total`         | Total number of failed scrapes for the target `source_id`                |
-| `last_total_attempted_scrapes` | Count of attempted scrapes during last round of scraping                 |
-| `last_total_failed_scrapes`    | Count of failed scrapes during last round of scraping                    |
-| `last_total_scrape_duration`   | Time in milliseconds to scrape all targets in last round of scraping     |
-| `scrape_targets_total`         | Total number of scrape targets identified from prom scraper config files |
-
-
-### <a id="svms"></a>SVMs
+### <a id="svms"></a> Super Value Metrics (svm-forwarder)
 
 The following metrics are Healthwatch 1.x metrics
-that are still available for use by turning on the SVM Forwarder.
+that are made available in the Loggregator Firehose for external use.
+They are created in Prometheus and are made available by the SVM Forwarder VM.
 See the [Release Notes](./release-notes.html#2-0-1) for more information.
 
 | Metric                                               | Description                                                                                         |
@@ -229,3 +230,91 @@ See the [Release Notes](./release-notes.html#2-0-1) for more information.
 | `health_check_cliCommand_stop`                       | Can CF stop?                                                                                        |
 | `health_check_cliCommand_success`                    | Overall success of the CF CLI SLI tests                                                             |
 | `uaa_throughput_rate`                                | UAA throughput rate                                                                                 |
+
+## <a id="component-monitoring-metrics"></a> Healthwatch Component Monitoring Metrics
+
+The following metrics exist for the purpose of monitoring the Healthwatch components.
+
+### <a id='pks-exporter'></a> PKS Exporter (pks-exporter)
+
+The PKS Exporter makes BOSH System metrics for PKS available in Prometheus.
+
+| Metric                                                     | Description                                                                                   |
+|------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `healthwatch_boshExporter_ingressLatency_seconds_bucket`   | Number of seconds it took to process a batch of Loggregator envelopes, grouped by latency     |
+| `healthwatch_boshExporter_ingressLatency_seconds_count`    | Total number of metrics in all the buckets                                                    |
+| `healthwatch_boshExporter_ingressLatency_seconds_sum`      | Total value of the metrics in all the buckets                                                 |
+| `healthwatch_boshExporter_ingress_envelopes`               | Number of envelopes received by observability metrics agent                                   |
+| `healthwatch_boshExporter_metricConversion_seconds_bucket` | Number of seconds it took to convert a bosh metric to a Prometheus gauge, grouped by duration |
+| `healthwatch_boshExporter_metricConversion_seconds_count`  | Total number of metrics in all the buckets                                                    |
+| `healthwatch_boshExporter_metricConversion_seconds_sum`    | Total value of the metrics in all the buckets                                                 |
+| `healthwatch_boshExporter_status`                          | Exporter status, a 1 indicates the exporter is running and healthy                            |
+
+### <a id='pas-exporters'></a> PAS Exporter VMs (pas-exporter-*)
+
+These following exporters take metrics from the Firehose
+and make them accessible on a Prometheus-compatible `/metrics` endpoint.
+
+Each of the following exporters handles a specific subset of the Firehose metrics.
+The names of the exporters correspond to the metrics they export.
+
+#### <a id='pas-exporter-counter'></a> PAS Counter Exporter (pas-exporter-counter)
+
+The PAS Counter Exporter makes Loggregator Firehose Counter metrics available in Prometheus.
+
+| Metric                                              | Description                                                                     |
+|-----------------------------------------------------|---------------------------------------------------------------------------------|
+| `healthwatch_pasExporter_counterConversion_seconds` | Number of seconds it took to convert a counter envelope to a Prometheus counter |
+| `healthwatch_pasExporter_evictedMetrics`            | Number of metrics evicted from exporter cache                                   |
+| `healthwatch_pasExporter_ingressLatency_seconds`    | Number of seconds it took process a batch of Loggregator envelopes              |
+| `healthwatch_pasExporter_ingress_envelopes`         | Number of envelopes received by observability metrics agent                     |
+| `healthwatch_pasExporter_status`                    | Exporter status, a 1 indicates the exporter is running and healthy              |
+
+#### <a id='pas-exporter-gauge'></a> PAS Gauge Exporter (pas-exporter-gauge)
+
+The PAS Gauge Exporter makes Loggregator Firehose Gauge metrics available in Prometheus.
+
+| Metric                                              | Description                                                                 |
+|-----------------------------------------------------|-----------------------------------------------------------------------------|
+| `healthwatch_pasExporter_evictedMetrics`            | Number of metrics evicted from exporter cache                               |
+| `healthwatch_pasExporter_gaugeConversion_seconds`   | Number of seconds it took to convert a gauge envelope to a Prometheus gauge |
+| `healthwatch_pasExporter_ingressLatency_seconds`    | Number of seconds it took process a batch of Loggregator envelopes          |
+| `healthwatch_pasExporter_ingress_envelopes`         | Number of envelopes received by observability metrics agent                 |
+| `healthwatch_pasExporter_status`                    | Exporter status, a 1 indicates the exporter is running and healthy          |
+
+#### <a id='pas-exporter-timer'></a> PAS Timer Exporter (pas-exporter-timer)
+
+The PAS Timer Exporter makes Loggregator Firehose Timer metrics available in Prometheus.
+
+| Metric                                              | Description                                                        |
+|-----------------------------------------------------|--------------------------------------------------------------------|
+| `healthwatch_pasExporter_evictedMetrics`            | Number of metrics evicted from exporter cache                      |
+| `healthwatch_pasExporter_ingressLatency_seconds`    | Number of seconds it took process a batch of Loggregator envelopes |
+| `healthwatch_pasExporter_ingress_envelopes`         | Number of envelopes received by observability metrics agent        |
+| `healthwatch_pasExporter_status`                    | Exporter status, a 1 indicates the exporter is running and healthy |
+
+### <a id="prometheus-exposition"></a> Prometheus Exposition
+
+These metrics come from by the majority of the exporter VMs and relate to the `/metrics` endpoint that Prometheus scrapes from.
+
+| Metric                                                    | Description                                                        |
+|-----------------------------------------------------------|--------------------------------------------------------------------|
+| `healthwatch_prometheusExpositionLatency_seconds`         | Number of seconds it took to render Prometheus scrape page         |
+| `healthwatch_prometheusExposition_expiredMetrics`         | Number of metrics expired from exporter cache                      |
+| `healthwatch_prometheusExposition_histogramMapConversion` | Time it takes to convert histogram collection to a map             |
+| `healthwatch_prometheusExposition_metricMapConversion`    | Time it takes to convert metrics collection to a map               |
+| `healthwatch_prometheusExposition_metricSorting`          | Time it takes to sort metrics when rendering Prometheus exposition |
+
+
+### <a id="svm-forwarder"></a> SVM Forwarder Monitoring Metrics (svm-forwarder)
+
+The SVM Forwarder makes Healthwatch 1.x Super Value Metrics available in the Loggregator Firehose for external use.
+See the [Release Notes](./release-notes.html#2-0-1) for more information.
+
+| Metric                         | Description                                                              |
+|--------------------------------|--------------------------------------------------------------------------|
+| `failed_scrapes_total`         | Total number of failed scrapes for the target `source_id`                |
+| `last_total_attempted_scrapes` | Count of attempted scrapes during last round of scraping                 |
+| `last_total_failed_scrapes`    | Count of failed scrapes during last round of scraping                    |
+| `last_total_scrape_duration`   | Time in milliseconds to scrape all targets in last round of scraping     |
+| `scrape_targets_total`         | Total number of scrape targets identified from prom scraper config files |

--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -24,21 +24,21 @@ for command line applications and processes. Thus, you will see a pattern emerge
 between certain metrics (`bosh_sli_...`, `pas_sli_...`, `pks_sli_...`).
 Here are the ones that `bosh`, `pas`, and `pks` should all have in common.
 
-| Metric                                                  | Description                                                                                                                      |
-|---------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `COMPONENT_deployments_status`                          | Bosh Deployments status, a 1 indicates a deployment is occurring on the director                                                 |
-| `COMPONENT_sli_duration_seconds_bucket`                 | Number of seconds it took for the SLI test suite to run, grouped by duration                                                     |
-| `COMPONENT_sli_duration_seconds_count`                  | Total number of metrics in all the buckets                                                                                       |
-| `COMPONENT_sli_duration_seconds_sum`                    | Total value of the metrics in all the buckets                                                                                    |
-| `COMPONENT_sli_exporter_status`                         | Exporter status, a 1 indicates the exporter is running and healthy                                                               |
-| `COMPONENT_sli_failures_total`                          | Total number of failures of the SLI test suite                                                                                   |
-| `COMPONENT_sli_run_duration_seconds`                    | Number of seconds it took for the SLI test suite to run                                                                          |
-| `COMPONENT_sli_runs_total`                              | Total number of runs of the SLI test suite. Use bosh_sli_failures_total / bosh_sli_runs_total to get failure rate.               |
-| `COMPONENT_sli_task_duration_seconds_bucket`            | Number of seconds it took for a particular task to run, grouped by duration                                                      |
-| `COMPONENT_sli_task_duration_seconds_count`             | Total number of metrics in all the buckets                                                                                       |
-| `COMPONENT_sli_task_duration_seconds_sum`               | Total value of the metrics in all the buckets                                                                                    |                                                                            |
-| `COMPONENT_sli_task_run_duration_seconds`               | Number of seconds it took for a particular task to run                                                                           |
-| `COMPONENT_sli_task_runs_total`                         | Total number of runs for a particular SLI task. Use bosh_sli_task_failures_total / bosh_sli_task_runs_total to get failure rate. |
+| Metric                                                  | Description                                                                                                                          |
+|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `COMPONENT_deployments_status`                          | Bosh Deployments status, a 1 indicates a deployment is occurring on the director                                                     |
+| `COMPONENT_sli_duration_seconds_bucket`                 | Number of seconds it took for the SLI test suite to run, grouped by duration                                                         |
+| `COMPONENT_sli_duration_seconds_count`                  | Total number of metrics in all the buckets                                                                                           |
+| `COMPONENT_sli_duration_seconds_sum`                    | Total value of the metrics in all the buckets                                                                                        |
+| `COMPONENT_sli_exporter_status`                         | Exporter status, a 1 indicates the exporter is running and healthy                                                                   |
+| `COMPONENT_sli_failures_total`                          | Total number of failures of the SLI test suite                                                                                       |
+| `COMPONENT_sli_run_duration_seconds`                    | Number of seconds it took for the SLI test suite to run                                                                              |
+| `COMPONENT_sli_runs_total`                              | Total number of runs of the SLI test suite. Use `bosh_sli_failures_total` / `bosh_sli_runs_total` to get failure rate.               |
+| `COMPONENT_sli_task_duration_seconds_bucket`            | Number of seconds it took for a particular task to run, grouped by duration                                                          |
+| `COMPONENT_sli_task_duration_seconds_count`             | Total number of metrics in all the buckets                                                                                           |
+| `COMPONENT_sli_task_duration_seconds_sum`               | Total value of the metrics in all the buckets                                                                                        |
+| `COMPONENT_sli_task_run_duration_seconds`               | Number of seconds it took for a particular task to run                                                                               |
+| `COMPONENT_sli_task_runs_total`                         | Total number of runs for a particular SLI task. Use `bosh_sli_task_failures_total` / `bosh_sli_task_runs_total` to get failure rate. |
 
 Where `COMPONENT` is the platform or CLI tested (e.g. `bosh`, `pas`, `pks`).
 
@@ -184,13 +184,13 @@ along with the response time metrics.
 
 ### <a id="svm-forwarder"></a>SVM Forwarder
 
-| Metric                         | Description                                                               |
-|--------------------------------|---------------------------------------------------------------------------|
-| `failed_scrapes_total`         | Total number of failed scrapes for the target source_id.                  |
-| `last_total_attempted_scrapes` | Count of attempted scrapes during last round of scraping.                 |
-| `last_total_failed_scrapes`    | Count of failed scrapes during last round of scraping.                    |
-| `last_total_scrape_duration`   | Time in milliseconds to scrape all targets in last round of scraping.     |
-| `scrape_targets_total`         | Total number of scrape targets identified from prom scraper config files. |
+| Metric                         | Description                                                              |
+|--------------------------------|--------------------------------------------------------------------------|
+| `failed_scrapes_total`         | Total number of failed scrapes for the target `source_id`                |
+| `last_total_attempted_scrapes` | Count of attempted scrapes during last round of scraping                 |
+| `last_total_failed_scrapes`    | Count of failed scrapes during last round of scraping                    |
+| `last_total_scrape_duration`   | Time in milliseconds to scrape all targets in last round of scraping     |
+| `scrape_targets_total`         | Total number of scrape targets identified from prom scraper config files |
 
 
 ### <a id="svms"></a>SVMs
@@ -201,31 +201,31 @@ See the [Release Notes](./release-notes.html#2-0-1) for more information.
 
 | Metric                                               | Description                                                                                         |
 |------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| `Diego_AppsDomainSynced`                             | ?                                                                                                   |
-| `Diego_AvailableFreeChunksDisk`                      | Diego Available Free Chunks of Disk                                                                 |
-| `Diego_AvailableFreeChunks`                          | Diego Available Free Chunks of Memory                                                               |
-| `Diego_LRPsAdded_1H`                                 | Rate of Change in Running App Instances                                                             |
-| `Diego_TotalAvailableDiskCapacity_5M`                | Remaining Cell Disk Available                                                                       |
-| `Diego_TotalAvailableMemoryCapacity_5M`              | Remaining Cell Memory Available                                                                     |
-| `Diego_TotalPercentageAvailableContainerCapacity_5M` | Diego Container Capacity                                                                            |
-| `Diego_TotalPercentageAvailableDiskCapacity_5M`      | Diego Cell Disk                                                                                     |
-| `Diego_TotalPercentageAvailableMemoryCapacity_5M`    | Diego Cell Memory                                                                                   |
-| `Doppler_MessagesAverage_1M`                         | Doppler Message Rate Average                                                                        |
-| `Firehose_LossRate_1H`                               | Log Transport Loss Rate                                                                             |
-| `Firehose_LossRate_1M`                               | Log Transport Loss Rate                                                                             |
-| `SyslogAgent_LossRate_1M`                            | Syslog Agent Loss Rate                                                                              |
-| `SyslogDrain_RLP_LossRate_1M`                        | Reverse Log Proxy Loss Rate                                                                         |
-| `bosh_deployment`                                    |                                                                                                     |
+| `Diego_AppsDomainSynced`                             | Whether or not Cloud Controller and Diego are in sync                                               |
+| `Diego_AvailableFreeChunksDisk`                      | Available free chunks of disk in Diego                                                              |
+| `Diego_AvailableFreeChunks`                          | Available free chunks of memory in Diego                                                            |
+| `Diego_LRPsAdded_1H`                                 | Rate of change in running app instances in 1 hour intervals                                         |
+| `Diego_TotalAvailableDiskCapacity_5M`                | Remaining cell disk available in Diego in 5 minute intervals                                        |
+| `Diego_TotalAvailableMemoryCapacity_5M`              | Remaining cell memory available in Diego in 5 minute intervals                                      |
+| `Diego_TotalPercentageAvailableContainerCapacity_5M` | Percentage of total available container capacity in Diego in 5 minute intervals                     |
+| `Diego_TotalPercentageAvailableDiskCapacity_5M`      | Percentage of total available disk in the Diego cells in 5 minute intervals                         |
+| `Diego_TotalPercentageAvailableMemoryCapacity_5M`    | Percentage of total available memory in the Diego cells in 5 minute intervals                       |
+| `Doppler_MessagesAverage_1M`                         | Average Doppler message rate in 1 minute intervals                                                  |
+| `Firehose_LossRate_1H`                               | Log transport loss rate in 1 hour intervals                                                         |
+| `Firehose_LossRate_1M`                               | Log transport loss rate in 1 minute intervals                                                       |
+| `SyslogAgent_LossRate_1M`                            | Syslog Agent loss rate in 1 minute intervals                                                        |
+| `SyslogDrain_RLP_LossRate_1M`                        | Reverse Log Proxy loss rate in 1 minute intervals                                                   |
+| `bosh_deployment`                                    | Represents `bosh_deployments_status`, a 1 indicates a deployment is occurring on the director       |
 | `health_check_bosh_director_success`                 | BOSH SLI test status, 1 indicates success                                                           |
-| `health_check_CanaryApp_available`                   | Canary App Availability                                                                             |
-| `health_check_CanaryApp_responseTime`                | Canary App Response Time                                                                            |
-| `health_check_cliCommand_delete`                     | Can CF Delete                                                                                       |
-| `health_check_cliCommand_login`                      | Can CF Login                                                                                        |
-| `health_check_cliCommand_logs`                       | Can Receive Logs                                                                                    |
-| `health_check_cliCommand_probe_count`                | Number of Healthwatch CLI Command Health probe assessments completed in the measured time interval. |
-| `health_check_cliCommand_pushTime`                   | CF Push Time                                                                                        |
-| `health_check_cliCommand_push`                       | Can CF Push                                                                                         |
-| `health_check_cliCommand_start`                      | Can CF Start                                                                                        |
-| `health_check_cliCommand_stop`                       | Can CF Stop                                                                                         |
+| `health_check_CanaryApp_available`                   | Whether the canary app is available                                                                 |
+| `health_check_CanaryApp_responseTime`                | Response time of the canary app                                                                     |
+| `health_check_cliCommand_delete`                     | Can CF delete?                                                                                      |
+| `health_check_cliCommand_login`                      | Can CF login?                                                                                       |
+| `health_check_cliCommand_logs`                       | Can receive logs?                                                                                   |
+| `health_check_cliCommand_probe_count`                | Number of Healthwatch CLI command health probe assessments completed in the measured time interval. |
+| `health_check_cliCommand_pushTime`                   | CF app push time                                                                                    |
+| `health_check_cliCommand_push`                       | Can CF push?                                                                                        |
+| `health_check_cliCommand_start`                      | Can CF start?                                                                                       |
+| `health_check_cliCommand_stop`                       | Can CF stop?                                                                                        |
 | `health_check_cliCommand_success`                    | Overall success of the CF CLI SLI tests                                                             |
-| `uaa_throughput_rate`                                | UAA Throughput Rate                                                                                 |
+| `uaa_throughput_rate`                                | UAA throughput rate                                                                                 |


### PR DESCRIPTION
Add missing metrics with descriptions and reformat tables to be in Markdown instead of HTML.