### PR TITLE
Update the bosh ssh for tsdb to specify an instance, and allow it to …

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -37,7 +37,7 @@ you can view the Prometheus UI by running the following command
 and then navigating to `localhost:8082` in your browser.
 
 ```
-bosh -d HEALTHWATCH-TILE-DEPLOYMENT-NAME ssh tsdb --opts='-L 8082:localhost:9090'
+bosh -d HEALTHWATCH-TILE-DEPLOYMENT-NAME ssh tsdb/0 --opts='-L 8082:localhost:9090'
 ```
 
 Where `HEALTHWATCH-TILE-DEPLOYMENT-NAME` is the name of the Healthwatch 2.x deployment
@@ -65,7 +65,7 @@ you can view the Alertmanager UI by running the following command
 and then navigating to `localhost:8080` in your browser.
 
 ```
-bosh -d HEALTHWATCH-TILE-DEPLOYMENT-NAME ssh tsdb --opts='-L 8080:localhost:10401'
+bosh -d HEALTHWATCH-TILE-DEPLOYMENT-NAME ssh tsdb/0 --opts='-L 8080:localhost:10401'
 ```
 
 Where `HEALTHWATCH-TILE-DEPLOYMENT-NAME` is the name of the Healthwatch 2.x deployment


### PR DESCRIPTION
From story: https://www.pivotaltracker.com/story/show/176209149

We just updated the ssh for bosh to include a `/0`. This is because the command will fail if an instance is not specified.