### PR TITLE
YAML is indented improperly

### DIFF
--- a/snippets/_cluster_scraping_config.md.erb
+++ b/snippets/_cluster_scraping_config.md.erb
@@ -1,38 +1,38 @@
 ```yaml
 ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
-        metadata:
-          name: healthwatch
-        rules:
-        - resources:
-            - pods/proxy
-            - pods
-            - nodes
-            - nodes/proxy
-            - namespace/pods
-            - endpoints
-            - services
-          verbs:
-            - get
-            - watch
-            - list
-          apiGroups:
-            - ""
-        - nonResourceURLs: ["/metrics"]
-          verbs: ["get"]
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: healthwatch
-        roleRef:
-          apiGroup: ""
-          kind: ClusterRole
-          name: healthwatch
-        subjects:
-        - apiGroup: ""
-          kind: User
-          name: healthwatch
-          namespace: pks-system
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: healthwatch
+rules:
+- resources:
+    - pods/proxy
+    - pods
+    - nodes
+    - nodes/proxy
+    - namespace/pods
+    - endpoints
+    - services
+  verbs:
+    - get
+    - watch
+    - list
+  apiGroups:
+    - ""
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: healthwatch
+roleRef:
+  apiGroup: ""
+  kind: ClusterRole
+  name: healthwatch
+subjects:
+- apiGroup: ""
+  kind: User
+  name: healthwatch
+  namespace: pks-system
 ```


### PR DESCRIPTION
If you copy and paste the example as is it fails due to improper indentation