### PR TITLE
Switch 'pks_*' to 'tkgi_*' metrics for alerting rules [#175751153]

### DIFF
--- a/common-configurations/tkg-i_alerting_rules.yml
+++ b/common-configurations/tkg-i_alerting_rules.yml
@@ -49,7 +49,7 @@ groups:
   - name: KubernetesSLITests
     rules:
       - alert: KubernetesSLITests
-        expr: 'increase(pks_sli_task_failures_total[2m]) <= 0'
+        expr: 'increase(tkgi_sli_task_failures_total[2m]) <= 0'
         for: 10m
         annotations:
           summary: "The Tanzu Kubernetes Grid Integrated Edition SLI test ({{ $labels.task }}) has been failing for at least 10 minutes."


### PR DESCRIPTION
Signed-off-by: Jeremy Alvis <jalvis@pivotal.io>