### PR TITLE
Fix broken markdown link

### DIFF
--- a/configuring/configuring-healthwatch.html.md.erb
+++ b/configuring/configuring-healthwatch.html.md.erb
@@ -194,8 +194,8 @@ calculate the available memory chunks SVM. If you rely on Pivotal Healthwatch v1
 for any metrics, the Pivotal Healthwatch integration then uses this SVM to calculate the `Diego_AvailableFreeChunksMemory`
 metric. The Pivotal Healthwatch integration sends the `Diego_AvailableFreeChunksMemory` metric
 back into Loggregator so third-party nozzles can send it to external destinations, such as
-a remote server or external aggregation service. For more information, see [SVM Forwarder VM
-- Platform Metrics](../metrics.html#svm-forwarder-platform) and [SVM Forwarder VM - Healthwatch
+a remote server or external aggregation service. For more information, see [SVM Forwarder
+VM - Platform Metrics](../metrics.html#svm-forwarder-platform) and [SVM Forwarder VM - Healthwatch
 Component Metrics](../metrics.html#svm-forwarder-components) in _Healthwatch Metrics_.
 
 1. Click **Save**.


### PR DESCRIPTION
This was appearing as in the staging docs:
```
Platform Metrics](../metrics.html#svm-forwarder-platform)
```
because there was a newline which wouldn't render the link