### PR TITLE
Update the version information

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -118,7 +118,7 @@ The following table provides version and version support information about Healt
 
 | Element | Details |
 | ------- | ------- |
-| Version | v2.1.1 |
+| Version | v2.1.3 |
 | Release date | May 14, 2021 |
 | Compatible Ops Manager versions | v2.7, v2.8, v2.9, v2.10 |
 | Compatible Pivotal Application Service (PAS) and TAS for VMs versions | v2.7, v2.8, v2.9, v2.10, v2.11 |

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -119,7 +119,7 @@ The following table provides version and version support information about Healt
 | Element | Details |
 | ------- | ------- |
 | Version | v2.1.3 |
-| Release date | May 14, 2021 |
+| Release date | July 15, 2021 |
 | Compatible Ops Manager versions | v2.7, v2.8, v2.9, v2.10 |
 | Compatible Pivotal Application Service (PAS) and TAS for VMs versions | v2.7, v2.8, v2.9, v2.10, v2.11 |
 | Compatible Enterprise Pivotal Container Service (Enterprise PKS) and TKGI versions | v1.8, v1.9, v1.10 |


### PR DESCRIPTION
The latest version of Healthwatch product is v2.1.3 as of September 2nd, 2021.