### PR TITLE
uaa authentication should only use TAS & TKGI UAAS

### DIFF
--- a/configuring/grafana-authentication.html.md.erb
+++ b/configuring/grafana-authentication.html.md.erb
@@ -206,67 +206,43 @@ tile, depending on which runtime is installed on your foundation.
 1. Select the **Credentials** tab.
 
 1. View and record the credentials to log in to the UAA instance for your runtime:
-    * If your Ops Manager deployment uses internal authentication:
-        1. View the credentials for the UAA admin client for your runtime:
-            * **For TAS for VMs:** In the **Admin Client Credentials** row of the **UAA** section,
+    * If you are using the UAA in Tanzu Application Service (TAS):
+        1. View the credentials for the UAA admin client:
+            * In the **Admin Client Credentials** row of the **UAA** section,
             click **Link to Credential**.
-            * **For TKGI:** In the **Pks Uaa Management Admin Client** row, click **Link to
+        1. Record the secret for the UAA admin client:
+            * Record the value of `password`. This value is the secret
+            for **Admin Client Credentials**.
+    * If you are using the UAA in Tanzu Kubernetes Grid Integrated Edition (TKGI):
+        1. View the credentials for the UAA admin client:
+            * In the **Pks Uaa Management Admin Client** row, click **Link to
             Credential**.
         1. Record the secret for the UAA admin client:
-            * **For TAS for VMs:** Record the value of `password`. This value is the secret
-            for **Admin Client Credentials**.
-            * **For TKGI:** Record the value of `secret`. This value is the secret for **Pks
+            * Record the value of `secret`. This value is the secret for **Pks
             Uaa Management Admin Client**.
-    * If your Ops Manager deployment uses SAML or LDAP authentication:
-        1. View the credentials for the UAA admin client for your runtime:
-            * **For TAS for VMs:** In the **Admin Client Credentials** row of the **UAA** section,
-            click **Link to Credential**.
-            * **For TKGI:** In the **Pks Uaa Management Admin Client** row, click **Link to
-            Credential**.
-        1. Record the secret for the UAA admin client:
-            * **For TAS for VMs:** Record the value of `password`. This value is the secret
-            for **Admin Client Credentials**.
-            * **For TKGI:** Record the value of `secret`. This value is the secret for **Pks
-            Uaa Management Admin Client**.
-        1. Return to the Ops Manager Installation Dashboard.
-        1. Click the **BOSH Director** tile.
-        1. Select the **Credentials** tab.
-        1. In the **Uaa Bosh Client Credentials** row of the **BOSH Director** section, click
-        **Link to Credential**.
-        1. Record the value of `password`. This value is the secret for **Uaa Bosh Client Credentials**.
 
 1. Target the server for the UAA instance for your runtime using the User Account and Authentication
 Command Line Interface (UAAC). Run:
 
     ```
-    uaac target uaa.UAA-DOMAIN
+    uaac target UAA-URL
     ```
-    Where `UAA-DOMAIN` is the domain of your UAA server.
+    Where `UAA-URL` is the url of your UAA server. For TAS, it is typically https://login.<system_domain>
+    where `system_domain` is the system domain set in the TAS tile. For TKGI, it is typically `https://TKGI-API:8443`
+    where `TKGI-API` is the API url of the TKGI service.
     <br>
     <br>
     For more information about the UAAC, see [Creating and Managing Users with the UAA CLI
     (UAAC)](https://docs.pivotal.io/application-service/uaa/uaa-user-management.html) in the
     TAS for VMs documentation.
 
-1. Log in to the UAA instance for your runtime:
-    * If your Ops Manager deployment uses internal authentication, run:
+1. Log in to the UAA instance for your runtime. Run:
 
         ```
         uaac token client get admin -s UAA-ADMIN-CLIENT-SECRET
         ```
         Where `UAA-ADMIN-CLIENT-SECRET` is the UAA admin client secret you recorded from the
         **Credentials** tab in your runtime tile in a previous step.
-    * If your Ops Manager deployment uses SAML or LDAP authentication:
-        1. Run:
-
-            ```
-            uaac token owner get login -s UAA-LOGIN-CLIENT-SECRET
-            ```
-            Where `UAA-LOGIN-CLIENT-SECRET` is the UAA login client secret you recorded from
-            the **Credentials** tab in the BOSH Director tile in a previous step.
-        1. When prompted, enter the UAA admin client username `admin` and the UAA admin client
-        secret you recorded from the **Credentials** tab in your runtime tile in a previous
-        step.
 
 1. Create a UAA client for the Grafana instance by running:
 
@@ -282,11 +258,7 @@ Command Line Interface (UAAC). Run:
     * `CLIENT-SECRET` is the secret you want to set for the UAA client.
     * `PROTOCOL` is either `http` or `https`, depending on the protocol you configured the
     Grafana instance to use in the **Grafana Configuration** pane of the Healthwatch tile.
-    * `GRAFANA-ROOT-URL` is the root URL for the Grafana instance. If the Grafana instance
-    uses HTTPS, include the port for the Grafana instance in `GRAFANA-ROOT-URL`. For example,
-    `https://GRAFANA-ROOT-URL:443`. The Grafana instance listens on either port `443` or `80`,
-    depending on whether you provide an SSL certificate in the **Enable HTTPS by providing
-    certificates** field in the **Grafana Configuration** pane of the Healthwatch tile.
+    * `GRAFANA-ROOT-URL` is the root URL used to access the Grafana UI.
 
 1. If you are using TKGI, you must manually create UAA user groups to map to administrator,
 editor, and viewer permissions for Grafana. Run:


### PR DESCRIPTION
Hey @cshollingsworth, I made some updates to the UAA authentication docs.  The are primarily focused around only using the UAA in TAS for Grafana authentication, and not the UAA in BOSH.  Let me know if you want to chat about the changes. 