### PR TITLE
Remove any mentions of the pas-exporter-timer

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -205,11 +205,6 @@ The table below describes the ports you must open for each Healthwatch Exporter 
     <td><code>8082</code></td>
   </tr>
   <tr>
-    <td><code>pas-exporter-timer</code></td>
-    <td>RLP nozzle</td>
-    <td><code>8082</code></td>
-  </tr>
-  <tr>
     <td><code>pas-sli-exporter</code></td>
     <td>
       <ul>

--- a/configuring/configuring-exporter-tas.html.md.erb
+++ b/configuring/configuring-exporter-tas.html.md.erb
@@ -108,8 +108,8 @@ information about service networks, see [Required Subnets](https://docs.pivotal.
 ## <a id='exporter-config'></a> (Optional) Configure TAS for VMs Metric Exporter VMs
 
 In the **TAS for VMs Metric Exporter VMs** pane, you configure static IP addresses for the metric exporter VMs that collect metrics from the Loggregator
-Firehose in TAS for VMs. There are three metric exporter VMs that each collect a single metric type from the Loggregator Firehose: counter, gauge, or timer.
-You can deploy all three VMs or any subset thereof. After generating these metrics, the metric exporter VMs convert them to a Prometheus exposition format on
+Firehose in TAS for VMs. There are two metric exporter VMs that each collect a single metric type from the Loggregator Firehose: counter or gauge.
+You can deploy both VMs or one individually. After generating these metrics, the metric exporter VMs convert them to a Prometheus exposition format on
 a secured endpoint.
 
 You can also deploy two other VMs: the TAS for VMs service level indicator (SLI) exporter VM and the certificate expiration metric exporter VM.
@@ -125,9 +125,6 @@ To configure the **TAS for VMs Metric Exporter VMs** pane:
 exporter VM.
 
 1. (Optional) For **Static IP address for gauge metric exporter VM**, enter a valid static IP address that you want to reserve for the gauge metric exporter
-VM.
-
-1. (Optional) For **Static IP address for timer metric exporter VM**, enter a valid static IP address that you want to reserve for the timer metric exporter
 VM.
 
 1. (Optional) For **Static IP address for TAS for VMs SLI exporter VM**, enter a valid static IP address that you want to reserve for the TAS for VMs SLI
@@ -399,7 +396,7 @@ Component Metrics](../metrics.html#svm-forwarder-components) in _Healthwatch Met
     to re-deploy Healthwatch Exporter for TAS for VMs after deploying the SVM Forwarder VM. For more information, see <a href="#apply-changes">Deploy
     Healthwatch Exporter for TAS for VMs</a> below.</p>
 
-1. (Optional) Healthwatch Exporter for TAS for VMs deploys the counter, gauge, and timer metric exporter VMs by default. If you do not want to collect all of
+1. (Optional) Healthwatch Exporter for TAS for VMs deploys the counter, and gauge metric exporter VMs by default. If you do not want to collect all of
 these metric types, set the instance count for the VMs associated with the metrics you do not want to collect to `0`.
 
 1. Click **Save**.

--- a/configuring/multi-foundation-monitoring.html.md.erb
+++ b/configuring/multi-foundation-monitoring.html.md.erb
@@ -53,7 +53,6 @@ foundation or the TKGI Control Plane. To add a scrape job for a Healthwatch Expo
   1. Record the following IP addresses:
     1. In the **TAS Counter Exporter** row, record the IP address of the counter metric exporter VM from the **IPs** column.
     1. In the **TAS Gauge Exporter** row, record the IP address of the gauge metric exporter VM from the **IPs** column.
-    1. In the **TAS Timer Exporter** row, record the IP address of the timer metric exporter VM from the **IPs** column.
   1. Select the **Credentials** tab.
   1. In the row for **Healthwatch Exporter Client Mtls**, click **Link to Credential**.
   1. Record the credentials for **Healthwatch Exporter Client Mtls**.
@@ -71,14 +70,12 @@ foundation or the TKGI Control Plane. To add a scrape job for a Healthwatch Expo
             - targets:
               - "GAUGE-EXPORTER-VM-IP-ADDRESS:9090"
               - "COUNTER-EXPORTER-VM-IP-ADDRESS:9090"
-              - "TIMER-EXPORTER-VM-IP-ADDRESS:9090"
         ```
         Where:
         * `FOUNDATION-NAME` is the name of the Ops Manager foundation you want to monitor.
         * `GAUGE-EXPORTER-VM-IP-ADDRESS` is the IP address of the gauge metric exporter VM that you recorded in a previous step.
         * `COUNTER-EXPORTER-VM-IP-ADDRESS` is the IP address of the counter metric exporter
         VM that you recorded in a previous step.
-        * `TIMER-EXPORTER-VM-IP-ADDRESS` is the IP address of the timer metric exporter VM that you recorded in a previous step.
   1. For **Certificate and private key for TLS**, enter the certificate and private key from **Healthwatch Exporter Client Mtls** that you recorded from the
   **Credentials** tab in the Healthwatch Exporter for TAS for VMs tile in a previous step.
   1. For **CA certificate for TLS**, enter the Ops Manager root CA that you retrieved in a previous step.

--- a/configuring/optional-config/tas_alerting_rules.yml
+++ b/configuring/optional-config/tas_alerting_rules.yml
@@ -244,13 +244,6 @@ groups:
           summary: "The Healthwatch Tanzu Application Service Gauge Exporter is down"
           description: |
             The Healthwatch Tanzu Application Service Gauge Exporter has been down for 10 minutes.
-      - alert: HealthwatchTASTimerExporter
-        expr: 'service_up{service="pas-exporter-timer"} < 1'
-        for: 10m
-        annotations:
-          summary: "The Healthwatch Tanzu Application Service Timer Exporter is down"
-          description: |
-            The Healthwatch Tanzu Application Service Timer Exporter has been down for 10 minutes.
   ##### END HEALTHWATCH ALERTING RULES #####
 
   ##### BEGIN MYSQL TILE ALERTING RULES #####

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -61,7 +61,7 @@ Healthwatch includes the following features:
       * SLIs for TKGI components
       * When Ops Manager certificates are due to expire
       * Canary URL tests for TAS for VMs apps
-      * Counter, gauge, and timer app logs for TAS for VMs from the Loggregator Firehose
+      * Counter, gauge, and container metrics from the TAS for VMs Loggregator Firehose
       * Super value metrics (SVMs)
       * BOSH system metrics for TKGI
       * VMs deployed by Healthwatch Exporter tiles
@@ -89,7 +89,7 @@ Healthwatch Exporter for TAS for VMs tile:
 
 * Canary URL tests for TAS for VMs apps
 
-* Counter, gauge, and timer app logs for TAS for VMs from the Loggregator Firehose
+* Counter, gauge, and container metrics from the TAS for VMs Loggregator Firehose
 
 * SVMs
 

--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -823,33 +823,6 @@ The following table describes each metric the gauge metric exporter VM collects 
   </tr>
 </table>
 
-#### <a id='pas-exporter-timer'></a> Timer Metric Exporter VM
-
-The timer metric exporter VM, `pas-exporter-timer`, collects timer metrics from the Loggregator Firehose and converts them into a Prometheus exposition
-format.
-
-The following table describes each metric the timer metric exporter VM collects and converts:
-
-<table>
-  <tr>
-    <th style="width: 55%">Metric</th>
-    <th style="width: 45%">Description</th>
-  </tr>
-  <tr>
-    <td><code>healthwatch_tasExporter_ingressLatency_seconds</code></td>
-    <td>The number of seconds the timer metric exporter VM takes to process a batch of Loggregator timer envelopes.</td>
-  </tr>
-  <tr>
-    <td><code>healthwatch_tasExporter_ingress_envelopes</code></td>
-    <td>The number of Loggregator timer envelopes that the observability metrics agent on the timer metric exporter VM receives.</td>
-  </tr>
-  <tr>
-    <td><code>healthwatch_tasExporter_status</code></td>
-    <td>The health status of the timer metric exporter VM. A value of <code>0</code> indicates that the timer metric exporter VM is not responding. A value of
-      <code>1</code> indicates that the timer metric exporter VM is running and healthy.</td>
-  </tr>
-</table>
-
 ### <a id="prometheus-exposition"></a> Prometheus Exposition Endpoint
 
 Most of the metric exporter VMs generate metrics concerning how the Prometheus instance interacts with the `/metrics` endpoint on each metric exporter VM.

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -46,6 +46,9 @@ more information, see [](#) below.
 
 * **[Bug Fix]** The TAS SLI Login test displaying success instead of failure on timeout.
 
+* **[Breaking Change]** The pas-exporter-timer VM has been removed from Healthwatch. This exporter was providing metrics that were not used. In order to reduce metric cardinality and IaaS resource usage, this exporter has been decommissioned.
+Removing this VM has no effect on Healthwatch's ability to monitor TAS.
+
 Healthwatch v2.2.0 uses the following open-source component versions:
 
 | Component    | Packaged Version |


### PR DESCRIPTION
Hey Chloe, we have decided to remove the pas-exporter-timer from 2.2. This is our PR to remove any mentions of it in our docs. Please review when you get a chance. 

Signed-off-by: Jerry Belmonte <jbelmonte@vmware.com>