### PR TITLE
Add known issue for TKGI 113

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -56,6 +56,8 @@ Timeouts Are Increased](#tas-sli-test-timeout) below.
 
 * **[Bug Fix]** The TAS for VMs SLI test for the `cf login` command displays success instead of failure upon timeout.
 
+* **[Known Issue]** TKGI v1.13 is currently not supported by Healthwatch.
+
 Healthwatch v2.2.0 uses the following open-source component versions:
 
 | Component    | Packaged Version |

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -17,6 +17,8 @@ v2.2 Limitations](index.html#healthwatch-limitations) in _Healthwatch_.
 
 **Release Date:** 1/21/2022
 
+<p class='note'><strong>Note:</strong> TKGI v1.13 is currently not supported by Healthwatch v2.2.0.</p>
+
 * **[Feature]** In new installations of Healthwatch, the **Routing rules** field in the **Alertmanager** configuration pane is pre-configured with a default
 set of routing rules. For more information, see [Default Routing Rules Are Pre-Configured for Alertmanager](#routing-rules-auto-config) below.
 
@@ -55,8 +57,6 @@ UI Dashboards Only Include Metrics for Current Canary Apps](#current-canary-apps
 Timeouts Are Increased](#tas-sli-test-timeout) below.
 
 * **[Bug Fix]** The TAS for VMs SLI test for the `cf login` command displays success instead of failure upon timeout.
-
-* **[Known Issue]** TKGI v1.13 is currently not supported by Healthwatch.
 
 Healthwatch v2.2.0 uses the following open-source component versions:
 


### PR DESCRIPTION
Hey Chloe, we wanted to include in our release notes that we currently do not support TKGI v1.13. This is our PR to add this to our docs. Please review when you get a chance.

Signed-off-by: Jerry Belmonte <jbelmonte@vmware.com>