### PR TITLE
Change back healthwatch_tasExporter metric that was not updated

### DIFF
--- a/metrics.html.md.erb
+++ b/metrics.html.md.erb
@@ -773,19 +773,19 @@ The following table describes each metric the counter metric exporter VM collect
     <th style="width: 45%">Description</th>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_counterConversion_seconds</code></td>
+    <td><code>healthwatch_pasExporter_counterConversion_seconds</code></td>
     <td>The number of seconds the counter metric exporter VM takes to convert a Loggregator counter envelope to a Prometheus counter.</td>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_ingressLatency_seconds</code></td>
+    <td><code>healthwatch_pasExporter_ingressLatency_seconds</code></td>
     <td>The number of seconds the counter metric exporter VM takes to process a batch of Loggregator counter envelopes.</td>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_ingress_envelopes</code></td>
+    <td><code>healthwatch_pasExporter_ingress_envelopes</code></td>
     <td>The number of Loggregator counter envelopes the observability metrics agent on the counter metric exporter VM receives.</td>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_status</code></td>
+    <td><code>healthwatch_pasExporter_status</code></td>
     <td>The health status of the counter metric exporter VM. A value of <code>0</code> indicates that the counter metric exporter VM is not responding. A
       value of <code>1</code> indicates that the counter metric exporter VM is running and healthy.</td>
   </tr>
@@ -804,20 +804,20 @@ The following table describes each metric the gauge metric exporter VM collects 
     <th style="width: 45%">Description</th>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_gaugeConversion_seconds</code></td>
+    <td><code>healthwatch_pasExporter_gaugeConversion_seconds</code></td>
     <td>The number of seconds the gauge metric exporter VM takes to convert a Loggregator gauge envelope to a Prometheus gauge.</td>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_ingressLatency_seconds</code></td>
+    <td><code>healthwatch_pasExporter_ingressLatency_seconds</code></td>
     <td>The number of seconds the gauge metric exporter VM takes to process a batch of Loggregator gauge envelopes.</td>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_ingress_envelopes</code></td>
+    <td><code>healthwatch_pasExporter_ingress_envelopes</code></td>
     <td>The number of Loggregator gauge envelopes the observability metrics agent on the gauge
       metric exporter VM receives.</td>
   </tr>
   <tr>
-    <td><code>healthwatch_tasExporter_status</code></td>
+    <td><code>healthwatch_pasExporter_status</code></td>
     <td>The health status of the gauge metric exporter VM. A value of <code>0</code> indicates that the gauge metric exporter VM is not responding. A value of
       <code>1</code> indicates that the gauge metric exporter VM is running and healthy.</td>
   </tr>


### PR DESCRIPTION
Hi Chloe, we need to update our 2.2 docs to reference the exporter metrics with the correct names. Currently, they are *tasExporter* and need to be *pasExporter*. This was probably done as part of our rename everything to tas, but these metrics weren't actually changed (most likely due to it being a breaking change). Thanks!