### PR TITLE
Fix example "Alert receiver configuration parameters" in slack alertmanager config

### DIFF
--- a/configuring/optional-config/alerting.html.md.erb
+++ b/configuring/optional-config/alerting.html.md.erb
@@ -212,9 +212,6 @@ with a dash. The following example shows a possible set of configuration paramet
     ```
     channel: '#operators'
     username: 'Example Alerting Integration'
-    actions:
-      text: "This is an alert."
-      type: 'error'
     ```
     The properties you must include depend on both the Slack instance for which you are configuring an alert receiver and the needs of your foundation. For
     more information about the properties you can include in this configuration, see the see the [Prometheus


### PR DESCRIPTION
The current alertmanager configuration snippet throws an error when applying changes in opsmanager, because we don't use `actions` .